### PR TITLE
⬆️ Upgrades Tailscale to 1.24.2

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -25,7 +25,7 @@ RUN \
     && if [ "${BUILD_ARCH}" = "i386" ]; then ARCH="386"; fi \
     \
     && curl -L -s \
-        "https://pkgs.tailscale.com/stable/tailscale_1.22.2_${ARCH}.tgz" \
+        "https://pkgs.tailscale.com/stable/tailscale_1.24.2_${ARCH}.tgz" \
         | tar zxvf - -C /opt/ --strip-components 1 \
     \
     && rm -f -r \


### PR DESCRIPTION
# Proposed Changes

Bump tailscale to the latest stable release

Stable releases: https://pkgs.tailscale.com/stable/#static