### PR TITLE
Update documentation on share_homeassistant option

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -241,7 +241,8 @@ More information: [Enabling HTTPS][tailscale_info_https],
 
 1. Home Assistant, by default, blocks requests from reverse proxies, like the
    Tailscale Serve. To enable it, add the following lines to your
-   `configuration.yaml`, without changing anything:
+   `configuration.yaml`, without changing anything (don't forget to restart Home
+   Assistant after the changes are saved):
 
    ```yaml
    http:


### PR DESCRIPTION
# Proposed Changes

Just a short reminder to unexperienced users.

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Home Assistant setup instructions for the Tailscale integration by adding an explicit reminder to restart Home Assistant after saving changes to configuration.yaml.
  * Updated wording in two locations to improve clarity and reduce confusion during setup.
  * No functional changes; examples and behavior remain the same, ensuring users understand the need to restart for changes to take effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->