### PR TITLE
Reinitialize bashio log outputs to the redirected stdout

### DIFF
--- a/tailscale/rootfs/etc/NetworkManager/dispatcher.d/protect-subnets
+++ b/tailscale/rootfs/etc/NetworkManager/dispatcher.d/protect-subnets
@@ -3,6 +3,12 @@
 export LOG_FD
 # The shebang 'with-contenv-merge' above is identical with 'with-contenv', but doesn't clear the current environment containing the dispatcher variables
 
+# Redirect outputs to the log (&2 is already set up as pipe by s6)
+exec 1>&2
+if [[ "${LOG_FD:-}" =~ ^[0-9]+$ ]]; then
+  eval "exec ${LOG_FD}>&1" || true
+fi
+
 function halt-app() {
   bashio::log.error "Failed to protect subnet routes. Halting app to prevent network loss."
   echo -n 1 > /run/s6-linux-init-container-results/exitcode

--- a/tailscale/rootfs/usr/bin/healthcheck
+++ b/tailscale/rootfs/usr/bin/healthcheck
@@ -9,8 +9,11 @@ export LOG_FD
 # - if once was online but gets offline for more then HEALTHCHECK_OFFLINE_TIMEOUT seconds
 # - if never gets online for more then HEALTHCHECK_RESTART_TIMEOUT seconds
 
-# Redirect healthchecks' output to the log
+# Redirect outputs to the log (&1 and &2 are not initialized by Docker)
 exec &> /proc/1/fd/1
+if [[ "${LOG_FD:-}" =~ ^[0-9]+$ ]]; then
+  eval "exec ${LOG_FD}>&1" || true
+fi
 
 readonly HEALTHCHECK_OFFLINE_TIMEOUT=300   # 5 minutes
 readonly HEALTHCHECK_RESTART_TIMEOUT=3600  # 1 hour


### PR DESCRIPTION
# Proposed Changes

After logging changes in bashio (https://github.com/hassio-addons/bashio/pull/169, https://github.com/hassio-addons/bashio/pull/172 and https://github.com/hassio-addons/bashio/pull/173) this is necessary even if https://github.com/hassio-addons/bashio/pull/174 got merged.

Though can be changed/refactored, if `eval "exec ${LOG_FD}>&1" || true` gets a nice bashio function by https://github.com/hassio-addons/bashio/pull/178.

## Related Issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container shutdown handling to ensure proper termination during failures
  * Enhanced logging capture mechanisms for better diagnostics and error tracking
  * Optimized healthcheck logging to support flexible log redirection configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->