### PR TITLE
Create persistent notification also (not just log warning) when key expiration is detected

### DIFF
--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -14,6 +14,7 @@ arch:
   - amd64
 init: false
 hassio_api: true
+homeassistant_api: true
 host_network: true
 host_dbus: true
 privileged:

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -6,7 +6,7 @@ export LOG_FD
 # Runs after the machine has been logged in into the Tailscale network
 # ==============================================================================
 
-source /usr/lib/core.sh
+source /usr/lib/api.core.sh
 
 declare interface
 declare -a options
@@ -158,7 +158,7 @@ if keyexpiry=$(/opt/tailscale status --self=true --peers=false --json | jq -rce 
           "Consider disabling key expiry to avoid losing connection to your Home Assistant device." \
           "You can use the [Machines page](https://login.tailscale.com/admin/machines) of Tailscale's admin console to disable key expiry." \
           "Please check your configuration based on the app's documentation under the \"Configuration\" section.")")
-    if core.api POST services/persistent_notification/create "${attributes}" -w > /dev/null; then
+    if api.core POST services/persistent_notification/create "${attributes}" -w > /dev/null; then
       touch "/data/key_expiry_notification_is_done"
     fi
   fi

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -5,6 +5,9 @@ export LOG_FD
 # Home Assistant Community App: Tailscale
 # Runs after the machine has been logged in into the Tailscale network
 # ==============================================================================
+
+source /usr/lib/core.sh
+
 declare interface
 declare -a options
 declare -a routes=()

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -158,7 +158,7 @@ if keyexpiry=$(/opt/tailscale status --self=true --peers=false --json | jq -rce 
           "Consider disabling key expiry to avoid losing connection to your Home Assistant device." \
           "You can use the [Machines page](https://login.tailscale.com/admin/machines) of Tailscale's admin console to disable key expiry." \
           "Please check your configuration based on the app's documentation under the \"Configuration\" section.")")
-    if api.core -w POST services/persistent_notification/create "${attributes}" > /dev/null; then
+    if api.core POST services/persistent_notification/create "${attributes}" -w > /dev/null; then
       touch "/data/key_expiry_notification_is_done"
     fi
   fi

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -158,7 +158,7 @@ if keyexpiry=$(/opt/tailscale status --self=true --peers=false --json | jq -rce 
           "Consider disabling key expiry to avoid losing connection to your Home Assistant device." \
           "You can use the [Machines page](https://login.tailscale.com/admin/machines) of Tailscale's admin console to disable key expiry." \
           "Please check your configuration based on the app's documentation under the \"Configuration\" section.")")
-    if api.core POST services/persistent_notification/create "${attributes}" -w > /dev/null; then
+    if api.core -w POST services/persistent_notification/create "${attributes}" > /dev/null; then
       touch "/data/key_expiry_notification_is_done"
     fi
   fi

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -158,8 +158,9 @@ if keyexpiry=$(/opt/tailscale status --self=true --peers=false --json | jq -rce 
           "Consider disabling key expiry to avoid losing connection to your Home Assistant device." \
           "You can use the [Machines page](https://login.tailscale.com/admin/machines) of Tailscale's admin console to disable key expiry." \
           "Please check your configuration based on the app's documentation under the \"Configuration\" section.")")
-    core.api POST services/persistent_notification/create "${attributes}" -w > /dev/null || true
-    touch "/data/key_expiry_notification_is_done"
+    if core.api POST services/persistent_notification/create "${attributes}" -w > /dev/null; then
+      touch "/data/key_expiry_notification_is_done"
+    fi
   fi
 fi
 

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -158,7 +158,7 @@ if keyexpiry=$(/opt/tailscale status --self=true --peers=false --json | jq -rce 
           "Consider disabling key expiry to avoid losing connection to your Home Assistant device." \
           "You can use the [Machines page](https://login.tailscale.com/admin/machines) of Tailscale's admin console to disable key expiry." \
           "Please check your configuration based on the app's documentation under the \"Configuration\" section.")")
-    core.api POST services/persistent_notification/create "${attributes}" -w > /dev/null
+    core.api POST services/persistent_notification/create "${attributes}" -w > /dev/null || true
     touch "/data/key_expiry_notification_is_done"
   fi
 fi

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -13,6 +13,7 @@ declare -a colliding_routes=()
 declare login_server
 declare tags
 declare keyexpiry
+declare attributes
 
 # Default options
 options+=(--hostname "$(bashio::info.hostname)")
@@ -139,9 +140,24 @@ fi
 
 # Warn about key expiration
 if keyexpiry=$(/opt/tailscale status --self=true --peers=false --json | jq -rce '.Self.KeyExpiry'); then
+  keyexpiry="${keyexpiry:0:10} ${keyexpiry:11:8} UTC"
+
   bashio::log.warning "The connection's key will expire on: ${keyexpiry}"
   bashio::log.warning "Consider disabling key expiry to avoid losing connection to your Home Assistant device."
-  bashio::log.warning "Please check your configuration based on the app's documentation under \"Configuration\""
+  bashio::log.warning "Please check your configuration based on the app's documentation under the \"Configuration\" section."
+
+  # Create persistent notification also, but only once
+  if ! bashio::fs.file_exists "/data/key_expiry_notification_is_done"; then
+    attributes=$(bashio::var.json \
+        title "Tailscale App" \
+        message "$(printf "%s\n\n" \
+          "**The connection's key will expire on: ${keyexpiry}!**" \
+          "Consider disabling key expiry to avoid losing connection to your Home Assistant device." \
+          "You can use the [Machines page](https://login.tailscale.com/admin/machines) of Tailscale's admin console to disable key expiry." \
+          "Please check your configuration based on the app's documentation under the \"Configuration\" section.")")
+    core.api POST services/persistent_notification/create "${attributes}" -w > /dev/null
+    touch "/data/key_expiry_notification_is_done"
+  fi
 fi
 
 # Warn about colliding subnet routes if non-userspace networking and accepting routes are enabled

--- a/tailscale/rootfs/usr/lib/api.core.sh
+++ b/tailscale/rootfs/usr/lib/api.core.sh
@@ -23,7 +23,7 @@ function log.error_or_warning() {
 #   -s "Silent" Supress error message in case of a 404 Not found HTTP status code
 #   -w "Warning only" Log only warnings instead of errors
 # ------------------------------------------------------------------------------
-function core.api() {
+function api.core() {
     local method="${1}"; shift
     local resource="/core/api/${1}"; shift
     local data='{}'
@@ -116,7 +116,8 @@ function core.api() {
 
     if bashio::var.has_value "${filter}"; then
         bashio::log.debug "Filtering response using: ${filter}"
-        response=$(bashio::jq "${response}" "${filter}")
+        response=$(bashio::jq "${response}" "${filter}") \
+            || return "${__BASHIO_EXIT_NOK}"
     fi
 
     echo "${response}"

--- a/tailscale/rootfs/usr/lib/api.core.sh
+++ b/tailscale/rootfs/usr/lib/api.core.sh
@@ -116,8 +116,11 @@ function api.core() {
 
     if bashio::var.has_value "${filter}"; then
         bashio::log.debug "Filtering response using: ${filter}"
-        response=$(bashio::jq "${response}" "${filter}") \
-            || return "${__BASHIO_EXIT_NOK}"
+        response=$(bashio::jq "${response}" "${filter}")
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to execute the jq filter"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
     fi
 
     echo "${response}"

--- a/tailscale/rootfs/usr/lib/core.sh
+++ b/tailscale/rootfs/usr/lib/core.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+function log.error_or_warning() {
+    local warning_only="$1"; shift
+    if ! bashio::var.has_value "${warning_only}"; then
+        bashio::log.error $*
+    else
+        bashio::log.warning $*
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Makes a call to the Home Assistant REST API.
+#
+# Arguments:
+#   $1 HTTP Method (GET/POST)
+#   $2 API Resource requested
+#   $3 In case of a POST method, this parameter is the JSON to POST (optional)
+#   $4 jq filter command (optional)
+#
+# Options (after arguments):
+#   -s "Silent" Supress error message in case of a 404 Not found HTTP status code
+#   -w "Warning only" Log only warnings instead of errors
+# ------------------------------------------------------------------------------
+function core.api() {
+    local method=${1}; shift
+    local resource="/core/api/${1}"; shift
+    local data='{}'
+    if [[ "${method}" = "POST" ]]; then
+        data=${1}; shift
+    fi
+    local filter=
+    if [[ ! -z ${1:-} && "${1::1}" != "-" ]]; then
+        filter=${1}; shift
+    fi
+
+    local OPTIND o a
+    local silent= local warning_only=
+    while getopts "sw" o; do
+        case "${o}" in
+            s)
+                silent=1
+                ;;
+            w)
+                warning_only=1
+                ;;
+        esac
+    done
+
+    local auth_header='Authorization: Bearer'
+    local response
+    local status
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if [[ -n "${__BASHIO_SUPERVISOR_TOKEN:-}" ]]; then
+        auth_header="Authorization: Bearer ${__BASHIO_SUPERVISOR_TOKEN}"
+    fi
+
+    if ! response=$(curl --silent --show-error \
+        --write-out '\n%{http_code}' --request "${method}" \
+        -H "${auth_header}" \
+        -H "Content-Type: application/json" \
+        -d "${data}" \
+        "${__BASHIO_SUPERVISOR_API}${resource}"
+    ); then
+        bashio::log.debug "${response}"
+        log.error_or_warning "${warning_only}" "Something went wrong contacting the API"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
+
+    status=${response##*$'\n'}
+    response=${response%"$status"}
+
+    bashio::log.debug "Requested API resource: ${__BASHIO_SUPERVISOR_API}${resource}"
+    bashio::log.debug "Request method: ${method}"
+    bashio::log.debug "Request data: ${data}"
+    bashio::log.debug "API HTTP Response code: ${status}"
+    bashio::log.debug "API Response: ${response}"
+
+    if [[ "${status}" -eq 400 ]]; then
+        log.error_or_warning "${warning_only}" "Requested resource ${resource} was called with a bad request"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
+
+    if [[ "${status}" -eq 401 ]]; then
+        log.error_or_warning "${warning_only}" "Unable to authenticate with the API, permission denied"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
+
+    if [[ "${status}" -eq 403 ]]; then
+        log.error_or_warning "${warning_only}" "Unable to access the API, forbidden"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
+
+    if [[ "${status}" -eq 404 ]]; then
+        if ! bashio::var.has_value "${silent}"; then
+            log.error_or_warning "${warning_only}" "Requested resource ${resource} was not found"
+        fi
+        return "${__BASHIO_EXIT_NOK}"
+    fi
+
+    if [[ "${status}" -eq 405 ]]; then
+        log.error_or_warning "${warning_only}" "Requested resource ${resource} was called using an unallowed method"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
+
+    if [[ "${status}" -ne 200 && "${status}" -ne 201 ]]; then
+        log.error_or_warning "${warning_only}" "Unknown HTTP error ${status} occurred"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
+
+    if bashio::var.has_value "${filter}"; then
+        bashio::log.debug "Filtering response using: ${filter}"
+        response=$(bashio::jq "${response}" "${filter}")
+    fi
+
+    echo "${response}"
+    return "${__BASHIO_EXIT_OK}"
+}

--- a/tailscale/rootfs/usr/lib/core.sh
+++ b/tailscale/rootfs/usr/lib/core.sh
@@ -31,7 +31,7 @@ function core.api() {
         data="${1}"; shift
     fi
     local filter=
-    if [[ ! -z "${1:-}" && "${1::1}" != "-" ]]; then
+    if [[ -n "${1:-}" && "${1::1}" != "-" ]]; then
         filter="${1}"; shift
     fi
 

--- a/tailscale/rootfs/usr/lib/core.sh
+++ b/tailscale/rootfs/usr/lib/core.sh
@@ -4,9 +4,9 @@
 function log.error_or_warning() {
     local warning_only="$1"; shift
     if ! bashio::var.has_value "${warning_only}"; then
-        bashio::log.error $*
+        bashio::log.error "$@"
     else
-        bashio::log.warning $*
+        bashio::log.warning "$@"
     fi
 }
 
@@ -35,8 +35,9 @@ function core.api() {
         filter=${1}; shift
     fi
 
-    local OPTIND o a
-    local silent= local warning_only=
+    local o
+    local silent=
+    local warning_only=
     while getopts "sw" o; do
         case "${o}" in
             s)
@@ -44,6 +45,8 @@ function core.api() {
                 ;;
             w)
                 warning_only=1
+                ;;
+            *)
                 ;;
         esac
     done

--- a/tailscale/rootfs/usr/lib/core.sh
+++ b/tailscale/rootfs/usr/lib/core.sh
@@ -24,15 +24,15 @@ function log.error_or_warning() {
 #   -w "Warning only" Log only warnings instead of errors
 # ------------------------------------------------------------------------------
 function core.api() {
-    local method=${1}; shift
+    local method="${1}"; shift
     local resource="/core/api/${1}"; shift
     local data='{}'
     if [[ "${method}" = "POST" ]]; then
-        data=${1}; shift
+        data="${1}"; shift
     fi
     local filter=
-    if [[ ! -z ${1:-} && "${1::1}" != "-" ]]; then
-        filter=${1}; shift
+    if [[ ! -z "${1:-}" && "${1::1}" != "-" ]]; then
+        filter="${1}"; shift
     fi
 
     local o


### PR DESCRIPTION
# Proposed Changes

 If we thought that this is the only warning we should highlight in the docs, it worths a notification.

But this will be created only once after install.

**Note to myself:** notification is also useful for invalid networking DNS config check, see: https://github.com/lmagyar/homeassistant-addon-tailscale/commit/6669e24249040cf68ebed22fb69e10e76a194298

<img width="467" height="320" alt="Image" src="https://github.com/user-attachments/assets/03b236bd-ce50-4e35-a3f4-2ed9fa55b670" />

## Related Issues

fixes #603


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled Home Assistant API integration via a new top-level flag.
  * Added a one-time persistent notification when a Tailscale key expiration is detected.

* **Improvements**
  * Reformatted key-expiration timestamps to "YYYY-MM-DD HH:MM UTC".
  * Introduced an API helper for supervisor REST calls with clearer logging, robust HTTP status handling, optional silent mode, and idempotent notification guarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->