### PR TITLE
Drop path for ipcalc

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/forwarding/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/forwarding/run
@@ -29,7 +29,7 @@ function get_forwardable_address() {
     fi
   fi
 
-  if ! ipinfo="$(/bin/ipcalc --json "${address}")"; then
+  if ! ipinfo="$(ipcalc --json "${address}")"; then
     bashio::log.debug "Address ${address} is not valid: ${ipinfo}"
     return 1
   fi

--- a/tailscale/rootfs/usr/bin/subnet-routes
+++ b/tailscale/rootfs/usr/bin/subnet-routes
@@ -55,7 +55,7 @@ else
         [[ $(</proc/sys/net/ipv4/ip_forward) -eq 0 ]] && continue
       fi
 
-      ipinfo="$(/bin/ipcalc --json "${address}")"
+      ipinfo="$(ipcalc --json "${address}")"
       routes+=("$(bashio::jq "${ipinfo}" '.NETWORK + "/" + .PREFIX')")
     fi
   done


### PR DESCRIPTION
# Proposed Changes

Continuation of #612

More future-proof to drop the path completely, /bin is in the PATH.

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved system utility resolution to enhance portability and cross-platform compatibility across different system configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->