### PR TITLE
Revert bashio related temporary workarounds after new bashio release in app base image

### DIFF
--- a/tailscale/rootfs/etc/NetworkManager/dispatcher.d/protect-subnets
+++ b/tailscale/rootfs/etc/NetworkManager/dispatcher.d/protect-subnets
@@ -1,6 +1,5 @@
 #!/command/with-contenv-merge bashio
 # shellcheck shell=bash
-export LOG_FD
 # The shebang 'with-contenv-merge' above is identical with 'with-contenv', but doesn't clear the current environment containing the dispatcher variables
 
 function halt-app() {

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/forwarding/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/forwarding/finish
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Remove forwarding

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/forwarding/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/forwarding/run
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Forward incoming tailnet connections to the host's primary interface

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Configures NGINX for use with the Tailscale web

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/local-network/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/local-network/run
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Wait for the local network (default HA interface) to be ready
 # ==============================================================================

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/finish
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Remove the MSS clamping

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Clamp the MSS to the MTU

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Take down the S6 supervision tree when Nginx fails

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Runs the Nginx daemon

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Runs after the machine has been logged in into the Tailscale network

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/protect-subnets/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/protect-subnets/finish
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Take down the S6 supervision tree when protect-subnets fails

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/protect-subnets/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/protect-subnets/run
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Prevent local subnets to be routed toward the tailnet

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/share-homeassistant/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/share-homeassistant/finish
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Take down the S6 supervision tree when share-homeassistant fails

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/share-homeassistant/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/share-homeassistant/run
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Enables Tailscale Serve or Funnel feature to share Home Assistant

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/taildrop/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/taildrop/finish
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Take down the S6 supervision tree when Taildrop fails

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/taildrop/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/taildrop/run
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Fetches files send via Taildrop

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/finish
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Take down the S6 supervision tree when Tailscale fails

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Runs tailscale

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/web/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/web/finish
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Take down the S6 supervision tree when Tailscale web fails

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/web/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/web/run
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # Runs tailscale web interface

--- a/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
+++ b/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Home Assistant Community App: Tailscale
 # S6 Overlay stage2 hook to customize services

--- a/tailscale/rootfs/usr/bin/healthcheck
+++ b/tailscale/rootfs/usr/bin/healthcheck
@@ -1,6 +1,5 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
-export LOG_FD
 
 # Plain (non-json) tailscale status returns error when status is not Running or Starting, so eg. NeedsLogin and NeedsMachineAuth would make it unhealthy
 # The .Health json filter returns any problems, so even temporary health problems would make it unhealthy

--- a/tailscale/rootfs/usr/bin/protect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/protect-subnet-routes
@@ -1,6 +1,5 @@
 #!/usr/bin/env bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # In case of non userspace networking,
 # add local subnets to ip rules with higher priority than Tailscale's routing

--- a/tailscale/rootfs/usr/bin/subnet-routes
+++ b/tailscale/rootfs/usr/bin/subnet-routes
@@ -1,6 +1,5 @@
 #!/usr/bin/env bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # Print possible subnet routes to stdout
 # ==============================================================================

--- a/tailscale/rootfs/usr/bin/unprotect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/unprotect-subnet-routes
@@ -1,6 +1,5 @@
 #!/usr/bin/env bashio
 # shellcheck shell=bash
-export LOG_FD
 # ==============================================================================
 # In case of non userspace networking,
 # remove local subnets from ip rules


### PR DESCRIPTION
# Proposed Changes

This will revert #568 and other bashio workarounds after these functionalities are released in bashio and app base image.

## Related Issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified service, networking, routing, and health-check scripts by removing an internal logging environment export.
  * Existing startup, shutdown, readiness, routing, protection, and health-check behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->