### PR TITLE
Fix DNS service: always resolve letsencrypt's api locally

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/init-magicdns-proxies-upstream-list/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/init-magicdns-proxies-upstream-list/run
@@ -38,10 +38,8 @@ if bashio::config.true "accept_dns"; then
     black_white_list+=("${LOG_SERVER}")
   fi
 
-  # If serve or funnel is used, resolve letsencrypt's api also
-  if ! bashio::config.equals 'share_homeassistant' 'disabled'; then
-    black_white_list+=("${LETSENCRYPT_API}")
-  fi
+  # Always resolve letsencrypt's api also (independent of share_homeassistant)
+  black_white_list+=("${LETSENCRYPT_API}")
 else
   # Add the tailnet domain as white list
   if ! tailnet=$( \


### PR DESCRIPTION
# Proposed Changes

Always enable letsencrypt's api in the DNS white-list.

If users configure other services with serve (with cli now, or maybe TS UI later), if this is not in the DNS whitelist, their connection will fail 3 months later, quite nasty to pin down the root cause.

## Related Issues
