### PR TITLE
feat: add configurable share path for serve and funnel

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -78,6 +78,7 @@ log_level: info
 login_server: "https://controlplane.tailscale.com"
 share_homeassistant: disabled
 share_on_port: 443
+share_path: "/"
 share_service_name: "svc:homeassistant"
 snat_subnet_routes: true
 stateful_filtering: false
@@ -322,6 +323,22 @@ internet.
 Only ports 443, 8443, and 10000 are allowed by Tailscale.
 
 Port 443 is used by default.
+
+### Option: `share_path`
+
+This option lets you specify the HTTP path that the Tailscale Serve and Funnel
+features will use to present your Home Assistant instance.
+
+By default, this option is set to `/` and exposes the full Home Assistant path
+space.
+
+You can set a narrower path, for example:
+
+- `/api/webhook/your-very-long-random-id`
+- `/api/`
+
+The value must start with `/` and must not include query strings (`?`) or URL
+fragments (`#`).
 
 ### Option: `share_service_name`
 

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -52,6 +52,7 @@ options:
   login_server: "https://controlplane.tailscale.com"
   share_homeassistant: disabled
   share_on_port: 443
+  share_path: /
   snat_subnet_routes: true
   stateful_filtering: false
   tags: []
@@ -78,6 +79,7 @@ schema:
   login_server: url
   share_homeassistant: list(disabled|serve|funnel)
   share_on_port: match(^(?:443|8443|10000)$)
+  share_path: "match(^\\/[^?#]*$)"
   share_service_name: "match(^svc:(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])$)?"
   snat_subnet_routes: bool
   stateful_filtering: bool

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/share-homeassistant/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/share-homeassistant/run
@@ -76,7 +76,7 @@ then
 fi
 options+=(--bg=false)
 options+=(--https="$(bashio::config 'share_on_port')")
-options+=(--set-path=/)
+options+=(--set-path="$(bashio::config 'share_path')")
 options+=(http://127.0.0.1:"$(bashio::core.port)")
 
 # This service can wait for HA for minutes, let notify S6 when we are really starting

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -74,6 +74,14 @@ configuration:
       internet.
       Only ports 443, 8443, and 10000 are allowed by Tailscale.
       Port 443 is used by default.
+  share_path:
+    name: Share path
+    description: >-
+      This option lets you specify the HTTP path the Tailscale Serve and Funnel
+      features will use to present your Home Assistant instance.
+      By default, it uses `/`, which exposes the full Home Assistant path space.
+      The value must start with `/` and must not include query strings (`?`) or
+      URL fragments (`#`).
   share_service_name:
     name: Share service name
     description: >-


### PR DESCRIPTION
# Proposed Changes

  Adds a new optional add-on configuration field: `share_path` (default: /) to control which HTTP path is exposed by Tailscale Serve/Funnel.

Why?
  - Today the add-on always uses --set-path=/, which exposes the full Home Assistant path space when share_homeassistant is enabled.
  - This change allows narrower exposure, e.g. /api/webhook/<id> or /api/, while keeping current behavior unchanged by default.

What changed:

- config.yaml
    - Added options.share_path: /
    - Added schema validation for share_path (must start with /, disallow ? and #)
- share-homeassistant runtime
    - Replaced hardcoded --set-path=/ with --set-path="$(bashio::config 'share_path')"
- Documentation and translations
    - Added docs and UI description for the new option with examples and constraints

Compatibility:
Backward compatible: existing installs remain unchanged because default is /.

Validation:

- Tested with share_path: "/api/webhook/" and confirmed exposed URL path works via Funnel.
- bash -n passed for modified shell script.
- YAML parse checks passed for modified YAML files.


Also validated in practice:
<img width="1027" height="580" alt="image" src="https://github.com/user-attachments/assets/b550f75f-3bd7-4d8c-90dd-58f3570e3780" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `share_path` configuration option for Tailscale Serve and Funnel integration, enabling customization of the HTTP path used to expose Home Assistant. Defaults to `/` with validation requiring paths to start with `/` and exclude query strings and URL fragments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->