### PR TITLE
Fix NetworkManager dispatcher script crashes due to s6-overlay changes

### DIFF
--- a/tailscale/rootfs/command/with-contenv-merge
+++ b/tailscale/rootfs/command/with-contenv-merge
@@ -6,7 +6,7 @@ ifelse
   eltest 0${S6_KEEP_ENV} -eq 0
 }
 {
-  s6-envdir -Lfn -- /run/s6/container_environment
+  s6-envdir -Lf -- /run/s6/container_environment
   exec
   $@
 }


### PR DESCRIPTION
# Proposed Changes

A change in s6-overlay in `with-contenv` script (https://github.com/just-containers/s6-overlay/commit/265a5a8b6a770cd1d92f249a38f6ed4ede50ff5d) must be copied into our modified `with-contenv-merge` script.

Note: I've added a subscription to the [atom feed](https://github.com/just-containers/s6-overlay/commits/master/layout/rootfs-overlay/package/admin/s6-overlay-%40VERSION%40/command/with-contenv.atom) of the original `with-contenv` script to not miss any future changes. 

## Related Issues

fixes #646

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal improvements to container environment handling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->