### PR TITLE
Remove service name option

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -78,7 +78,6 @@ log_level: info
 login_server: "https://controlplane.tailscale.com"
 share_homeassistant: disabled
 share_on_port: 443
-share_service_name: "svc:homeassistant"
 snat_subnet_routes: true
 stateful_filtering: false
 tags:
@@ -318,20 +317,6 @@ Only ports 443, 8443, and 10000 are allowed by Tailscale.
 
 Port 443 is used by default.
 
-### Option: `share_service_name`
-
-This option lets you specify the service name the Tailscale Serve feature will
-use to present your Home Assistant instance on the tailnet. It needs to start
-with `svc:`.
-
-**Note:** The Tailscale Funnel feature will ignore this option.
-
-More information: [Services][tailscale_info_services]
-
-This option is unused by default. To make it visible on the configuration
-editor, click "Show unused optional configuration options" at the bottom of the
-page.
-
 ### Option: `snat_subnet_routes`
 
 This option allows subnet devices to see the traffic originating from the subnet
@@ -560,7 +545,6 @@ SOFTWARE.
 [tailscale_info_pi_hole]: https://tailscale.com/docs/solutions/block-ads-all-devices-anywhere-using-raspberry-pi
 [tailscale_info_quad100]: https://tailscale.com/docs/reference/quad100
 [tailscale_info_serve]: https://tailscale.com/docs/features/tailscale-serve
-[tailscale_info_services]: https://tailscale.com/docs/features/tailscale-services
 [tailscale_info_site_to_site]: https://tailscale.com/docs/features/site-to-site
 [tailscale_info_subnets]: https://tailscale.com/docs/features/subnet-routers
 [tailscale_info_tags]: https://tailscale.com/docs/features/tags

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -78,7 +78,6 @@ schema:
   login_server: url
   share_homeassistant: list(disabled|serve|funnel)
   share_on_port: match(^(?:443|8443|10000)$)
-  share_service_name: "match(^svc:(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])$)?"
   snat_subnet_routes: bool
   stateful_filtering: bool
   tags:

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/share-homeassistant/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/share-homeassistant/run
@@ -69,11 +69,6 @@ if bashio::config.equals 'share_homeassistant' 'funnel'; then
 fi
 
 options+=("$(bashio::config 'share_homeassistant')")
-if bashio::config.equals 'share_homeassistant' 'serve' && \
-  bashio::config.has_value 'share_service_name'
-then
-  options+=(--service="$(bashio::config 'share_service_name')")
-fi
 options+=(--bg=false)
 options+=(--https="$(bashio::config 'share_on_port')")
 options+=(--set-path=/)

--- a/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
+++ b/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
@@ -8,6 +8,7 @@ export LOG_FD
 
 declare options
 declare proxy funnel proxy_and_funnel_port
+declare share_service_name
 
 # This is to execute potentially failing supervisor api functions within conditions,
 # where set -e is not propagated inside the function and bashio relies on set -e for api error handling
@@ -57,6 +58,13 @@ fi
 if bashio::var.has_value "${proxy_and_funnel_port}"; then
     bashio::log.info 'Removing deprecated proxy_and_funnel_port option'
     bashio::addon.option 'proxy_and_funnel_port'
+fi
+
+# Remove deprecated share_service_name option
+share_service_name=$(bashio::jq "${options}" '.share_service_name | select(.!=null)')
+if bashio::var.has_value "${share_service_name}"; then
+    bashio::log.info 'Removing deprecated share_service_name option'
+    bashio::addon.option 'share_service_name'
 fi
 
 # MagicDNS related service dependencies:

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -74,12 +74,6 @@ configuration:
       internet.
       Only ports 443, 8443, and 10000 are allowed by Tailscale.
       Port 443 is used by default.
-  share_service_name:
-    name: Share service name
-    description: >-
-      This option lets you specify the service name the Tailscale Serve feature will
-      use to present your Home Assistant instance on the tailnet. It needs to start
-      with `svc:`.
   snat_subnet_routes:
     name: Source NAT subnet routes
     description: >-


### PR DESCRIPTION
# Proposed Changes

This option is for background tailscale serve services only, but sharing HA with serve/funnel is a forward service intentionally, so this was a mistake to add it. (It was background-only even when I wrote the original PR (#626), so that wasn't tested correctly.)

```
Error: --service flag is only compatible with background mode
```

## Related Issues

fixes #657


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the deprecated `share_service_name` configuration option
  * Existing configurations using this option will be automatically migrated and removed
  * Updated documentation and translation strings accordingly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->