### PR TITLE
Support Supervised installations

### DIFF
--- a/tailscale/apparmor.txt
+++ b/tailscale/apparmor.txt
@@ -36,6 +36,13 @@ profile tailscale flags=(attach_disconnected,mediate_deleted) {
   capability chown,
   capability kill,
 
+  # For supervised installations - networking rules derived from complain mode analysis
+  network inet dgram,
+  network inet6 dgram,
+  network inet stream,
+  network inet6 stream,
+  network netlink raw,
+
   # General - based on Config.yaml
   capability net_admin,
   capability net_raw,


### PR DESCRIPTION
# Proposed Changes

For supervised installations add networking rules to apparmor.txt (derived from complain mode analysis). Apparmor is there for the MagicDNS fix.

I know supervised is not supported, but people still use it.

Your project, your decision whether to merge it.

## Related Issues

Fixes #659


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded network access permissions for IPv4/IPv6 datagram, stream, and netlink socket operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->