### PR TITLE
In case of invalid networking DNS settings disable MagicDNS to enable the app to start up

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/init-magicdns-ingress-proxy/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/init-magicdns-ingress-proxy/run
@@ -38,7 +38,8 @@ for dns in $(bashio::dns.locals); do
   if bashio::var.equals "${dns}" "dns://${MAGIC_DNS_IPV4}" || \
     bashio::var.equals "${dns}" "dns://${MAGIC_DNS_IPV6}"
   then
-    bashio::log.fatal "Do not configure MagicDNS's IP address (${dns:6}) as DNS server under Settings -> System -> Network"
+    bashio::log.fatal \
+      "Do not configure MagicDNS's IP address (${dns:6}) as DNS server under Settings -> System -> Network"
     invalid_dns_config="true"
   fi
 done

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/init-magicdns-ingress-proxy/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/init-magicdns-ingress-proxy/run
@@ -37,7 +37,8 @@ for dns in $(bashio::dns.locals); do
   if bashio::var.equals "${dns}" "dns://${MAGIC_DNS_IPV4}" || \
     bashio::var.equals "${dns}" "dns://${MAGIC_DNS_IPV6}"
   then
-    bashio::log.fatal "Do not configure MagicDNS's IP address (${dns:6}) as DNS server under Settings -> System -> Network"
+    bashio::log.fatal \
+      "Do not configure MagicDNS's IP address (${dns:6}) as DNS server under Settings -> System -> Network"
     invalid_dns_config="true"
   fi
 done

--- a/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
+++ b/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
@@ -10,6 +10,11 @@ declare options
 declare proxy funnel proxy_and_funnel_port
 declare share_service_name
 
+readonly MAGIC_DNS_IPV4="100.100.100.100"
+readonly MAGIC_DNS_IPV6="fd7a:115c:a1e0::53"
+declare dns
+declare invalid_dns_config
+
 # This is to execute potentially failing supervisor api functions within conditions,
 # where set -e is not propagated inside the function and bashio relies on set -e for api error handling
 function try {
@@ -65,6 +70,29 @@ share_service_name=$(bashio::jq "${options}" '.share_service_name | select(.!=nu
 if bashio::var.has_value "${share_service_name}"; then
     bashio::log.info 'Removing deprecated share_service_name option'
     bashio::addon.option 'share_service_name'
+fi
+
+# Check DNS configuration
+# This is identical with the check in init-magicdns-ingress-proxy/run
+# This check is to modify the configuration to prevent the check in init-magicdns-ingress-proxy/run from stopping the app startup
+invalid_dns_config="false"
+for dns in $(bashio::dns.locals); do
+    if bashio::var.equals "${dns}" "dns://${MAGIC_DNS_IPV4}" || \
+        bashio::var.equals "${dns}" "dns://${MAGIC_DNS_IPV6}"
+    then
+        bashio::log.warning \
+            "Do not configure MagicDNS's IP address (${dns:6}) as DNS server under Settings -> System -> Network"
+        invalid_dns_config="true"
+    fi
+done
+if bashio::var.true "${invalid_dns_config}"; then
+    bashio::log.warning \
+        "Due to invalid networking DNS configuration, userspace_networking option will be enabled to disable MagicDNS"
+    bashio::log.warning \
+        "Please check your configuration based on the app's documentation under the \"DNS\" section"
+    bashio::log.warning \
+        "After the issue is fixed you can disable userspace_networking option again and restart the app"
+    bashio::addon.option 'userspace_networking' 'true'
 fi
 
 # MagicDNS related service dependencies:

--- a/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
+++ b/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
@@ -9,6 +9,11 @@ declare options
 declare proxy funnel proxy_and_funnel_port
 declare share_service_name
 
+readonly MAGIC_DNS_IPV4="100.100.100.100"
+readonly MAGIC_DNS_IPV6="fd7a:115c:a1e0::53"
+declare dns
+declare invalid_dns_config
+
 # Load app options, even deprecated one to upgrade
 options=$(bashio::app.options)
 
@@ -55,6 +60,29 @@ share_service_name=$(bashio::jq "${options}" '.share_service_name | select(.!=nu
 if bashio::var.has_value "${share_service_name}"; then
     bashio::log.info 'Removing deprecated share_service_name option'
     bashio::app.option 'share_service_name'
+fi
+
+# Check DNS configuration
+# This is identical with the check in init-magicdns-ingress-proxy/run
+# This check is to modify the configuration to prevent the check in init-magicdns-ingress-proxy/run from stopping the app startup
+invalid_dns_config="false"
+for dns in $(bashio::dns.locals); do
+    if bashio::var.equals "${dns}" "dns://${MAGIC_DNS_IPV4}" || \
+        bashio::var.equals "${dns}" "dns://${MAGIC_DNS_IPV6}"
+    then
+        bashio::log.warning \
+            "Do not configure MagicDNS's IP address (${dns:6}) as DNS server under Settings -> System -> Network"
+        invalid_dns_config="true"
+    fi
+done
+if bashio::var.true "${invalid_dns_config}"; then
+    bashio::log.warning \
+        "Due to invalid networking DNS configuration, userspace_networking option will be enabled to disable MagicDNS"
+    bashio::log.warning \
+        "Please check your configuration based on the app's documentation under the \"DNS\" section"
+    bashio::log.warning \
+        "After the issue is fixed you can disable userspace_networking option again and restart the app"
+    bashio::app.option 'userspace_networking' 'true'
 fi
 
 # MagicDNS related service dependencies:


### PR DESCRIPTION
# Proposed Changes

Currently the app intentionally can't start if MagicDNS is configured in network settings as DNS server and MagicDNS is enabled (ie. userspace networking is disabled).

With this change, if invalid config is detected, userspace networking will be enabled, ie. MagicDNS will be disabled, and a long warning is logged, but the app can start at least.

## Related Issues

fixes #659
fixes #651


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added automatic detection of MagicDNS DNS server configurations during startup, which now intelligently enables userspace networking when needed for optimal compatibility.

* **Refactor**
  * Improved error logging formatting for DNS configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->