### PR TITLE
Remove unnecessary NetworkManager/dispatcher.d scripts from Alpine package

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -23,6 +23,9 @@ RUN \
     && ln -sf /sbin/xtables-nft-multi /sbin/ip6tables \
     && ln -sf /sbin/xtables-nft-multi /sbin/iptables \
     \
+    && rm -f -r \
+        /usr/lib/NetworkManager/dispatcher.d \
+    \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \
     && if [ "${BUILD_ARCH}" = "amd64" ]; then ARCH="amd64"; fi \
     \


### PR DESCRIPTION
# Proposed Changes

They are added to NetworkManager 1.54.3-r0 (Alpine 3.23).

Causing errors in log: `/usr/lib/NetworkManager/dispatcher.d/pre-up.d/90-nm-cloud-setup.sh: line 15: systemctl: not found`

## Related Issues

fixes #678

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image by removing unnecessary system components, reducing image size and improving build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->