### PR TITLE
Redirect LOG_FD also when suppressing log messages

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/forwarding/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/forwarding/run
@@ -76,7 +76,7 @@ function setup_forwarding() {
   fi
 }
 
-if ! bashio::api.supervisor GET "/network/interface/default/info" false &> /dev/null; then
+if ! eval "bashio::api.supervisor GET /network/interface/default/info false &> /dev/null ${LOG_FD}> /dev/null"; then
   bashio::log.warning \
     "The host has no primary (default) interface, can't forward incoming tailnet connections to the host." \
     "Restart of the app is required after the issue is fixed!"

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/local-network/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/local-network/run
@@ -14,7 +14,7 @@ declare wait_counter=0
 # They can mark this service as dependency, and wait for the successful startup.
 
 # Until HA has no default interface, we wait a little
-while ! bashio::api.supervisor GET "/network/interface/default/info" false &> /dev/null; do
+while ! eval "bashio::api.supervisor GET /network/interface/default/info false &> /dev/null ${LOG_FD}> /dev/null"; do
   if (( wait_counter++ == WAIT_COUNT )); then
     # We emit only a warning to let the app start, maybe this is the only connection to access the device, better to start than not.
     # Let Tailscale figure out a way to connect to the tailnet if the local network is temporarily down.

--- a/tailscale/rootfs/usr/bin/protect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/protect-subnet-routes
@@ -26,8 +26,8 @@ if [[ "${1-}" != "tested" ]]; then
   # It is possible to get "ERROR: Got unexpected response from the API: System is not ready with state: setup"
   # Test both networking and config Supervisor API availability, these APIs are called in subnet-routes script
   # And wait a little on inaccessibility
-  while ! bashio::api.supervisor GET "/network/interface/default/info" false &> /dev/null || \
-    ! bashio::api.supervisor GET "/addons/self/options/config" false &> /dev/null
+  while ! eval "bashio::api.supervisor GET /network/interface/default/info false &> /dev/null ${LOG_FD}> /dev/null" || \
+    ! eval "bashio::api.supervisor GET /addons/self/options/config false &> /dev/null ${LOG_FD}> /dev/null"
   do
     if (( wait_counter++ == WAIT_COUNT )); then
       bashio::exit.nok "Supervisor is unreachable"


### PR DESCRIPTION
# Proposed Changes

Sadly we must use eval, `${LOG_FD}> /dev/null` never redirected, only string constants (like `10> /dev/null` are interpreted as file descriptor. This is how bash works.

## Related Issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal supervisor API call execution and logging configuration across startup initialization scripts to enhance reliability and consistency in command processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->