### PR TITLE
Properly close s6 notification file descriptors

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-egress-proxy/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-egress-proxy/run
@@ -71,6 +71,7 @@ fi
 # We need to delay the starting of the dependent services until the conf file is written
 echo "nameserver ${DNSMASQ_EGRESS_ADDRESS_IPV4}" > /etc/resolv.dnsmasq.conf
 echo "" >&3
+exec 3>&-
 
 # This DNS forwards the white_list to HA's DNS, otherwise replies NXDOMAIN for everything
 # It must run on port 53 to be able to specify it in a resolv.conf

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-ingress-proxy/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-ingress-proxy/run
@@ -84,6 +84,7 @@ magicdns-ingress-proxy-forwarding remove drop
 
 # We need to delay the starting of the dependent services until iptables are configured
 echo "" >&3
+exec 3>&-
 
 # This DNS replies NXDOMAIN for the black_list, otherwise forwards everything to MagicDNS
 exec dnsmasq "${options[@]}"

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/share-homeassistant/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/share-homeassistant/run
@@ -76,6 +76,7 @@ options+=(http://127.0.0.1:"$(bashio::core.port)")
 
 # This service can wait for HA for minutes, let notify S6 when we are really starting
 echo "" >&3
+exec 3>&-
 
 # Set up serve or funnel
 exec /opt/tailscale "${options[@]}"


### PR DESCRIPTION
# Proposed Changes

s6 docs says: "daemons can simply write a line to a file descriptor of their choice, **then close that file descriptor**" https://skarnet.org/software/s6/notifywhenup.html

## Related Issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup in Tailscale and DNS services to prevent resource leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->