### PR TITLE
Use release drafter as standalone workflow again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,7 @@ on:
 
 permissions:
   actions: read
-  contents: write
-  pull-requests: read
+  contents: read
   packages: read
   security-events: write
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,8 +16,7 @@ jobs:
   ci:
     permissions:
       actions: read
-      contents: write
-      pull-requests: read
+      contents: read
       packages: read
       security-events: write
     uses: hassio-addons/workflows/.github/workflows/app-ci.yaml@3846ae0fd09acec8ac1ac308ceacd052b9d01bec # v2.0.6

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,16 @@
+---
+name: Release Drafter
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  workflows:
+    uses: hassio-addons/workflows/.github/workflows/release-drafter.yaml@xxxxxxx # v2.0.6+


### PR DESCRIPTION
This is draft, because it waits for a new workflow repo release!

# Proposed Changes

After https://github.com/hassio-addons/workflows/pull/291 it reverts #638 and #639.

## Related Issues

