### PR TITLE
Graceful shutdown on SIGTERM caused by manual app stop

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
@@ -15,7 +15,7 @@ bashio::log.info \
   "(by signal ${exit_code_signal})"
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
-  if [[ "${exit_code_container}" -eq 0 ]]; then
+  if [[ "${exit_code_signal}" -ne 15 && "${exit_code_container}" -eq 0 ]]; then
     echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/share-homeassistant/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/share-homeassistant/finish
@@ -15,7 +15,7 @@ bashio::log.info \
   "(by signal ${exit_code_signal})"
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
-  if [[ "${exit_code_container}" -eq 0 ]]; then
+  if [[ "${exit_code_signal}" -ne 15 && "${exit_code_container}" -eq 0 ]]; then
     echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/taildrop/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/taildrop/finish
@@ -15,7 +15,7 @@ bashio::log.info \
   "(by signal ${exit_code_signal})"
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
-  if [[ "${exit_code_container}" -eq 0 ]]; then
+  if [[ "${exit_code_signal}" -ne 15 && "${exit_code_container}" -eq 0 ]]; then
     echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/finish
@@ -15,7 +15,7 @@ bashio::log.info \
   "(by signal ${exit_code_signal})"
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
-  if [[ "${exit_code_container}" -eq 0 ]]; then
+  if [[ "${exit_code_signal}" -ne 15 && "${exit_code_container}" -eq 0 ]]; then
     echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/web/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/web/finish
@@ -15,7 +15,7 @@ bashio::log.info \
   "(by signal ${exit_code_signal})"
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
-  if [[ "${exit_code_container}" -eq 0 ]]; then
+  if [[ "${exit_code_signal}" -ne 15 && "${exit_code_container}" -eq 0 ]]; then
     echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt


### PR DESCRIPTION
# Proposed Changes

This is to prevent showing "Error" app status after plain manual app stop.

Finish scripts in pending PRs #667 #680 are also modified.

## Related Issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service termination and exit code handling across multiple background services to ensure proper shutdown behavior under specific conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->