### PR TITLE
⬆️ Update tailscale/tailscale to v1.98.9

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base
 ARG BUILD_ARCH=amd64
-ARG TAILSCALE_VERSION="v1.98.8"
+ARG TAILSCALE_VERSION="v1.98.9"
 RUN \
     apk add --no-cache \
         bind-tools=9.20.24-r0 \


### PR DESCRIPTION
## Summary

Bumps the bundled Tailscale from **v1.98.8 → v1.98.9** to pick up fixes for a set of **Tailscale SSH authentication vulnerabilities**. `main` is currently pinned to 1.98.8, which remains affected.

## Security context

Per the [Tailscale security bulletins](https://tailscale.com/security-bulletins), the following are fixed in **1.98.9**:

- **TS-2026-009** — Insecure SSH command-line argument handling. A username beginning with `-` (e.g. `-i`) is interpreted as a flag by `getent`, allowing an attacker to obtain a **`root`** session in violation of ACLs.
- **TS-2026-006** — SSH `root` bypass via numeric UID (`0@host`), circumventing ACL restrictions.
- **TS-2026-004** — SSH unix-socket forwarding symlink bypass.

Given that TS-2026-009 is an ACL-bypassing root escalation over Tailscale SSH, this should be treated as a **security-priority** update rather than a routine version bump.

## Changes

- `tailscale/Dockerfile`: `ARG TAILSCALE_VERSION` `v1.98.8` → `v1.98.9`

Verified that both the `amd64` and `arm64` 1.98.9 stable tarballs are available at the URL the Dockerfile fetches. 1.98.9 is also the current latest stable.

## Note

Renovate is configured to auto-merge Tailscale patch bumps and will likely open its own PR for 1.98.9 shortly; this manual PR is intended to land the fix faster given the severity. Close whichever is redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Tailscale version to v1.98.9.
  * Includes the latest Tailscale build during container image creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->