### PR TITLE
👷 Replace Repology with Alpine CDN datasource for package pins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,12 @@
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
+  "customDatasources": {
+    "alpine": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/",
+      "format": "html"
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -25,8 +31,9 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-_]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
       ],
       "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_24/{{package}}"
+      "datasourceTemplate": "custom.alpine",
+      "depNameTemplate": "alpine_3_24/{{package}}",
+      "extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"
     },
     {
       "customType": "regex",
@@ -40,8 +47,16 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true
+    },
+    {
+      "description": "Packages that live in the Alpine community repository",
+      "matchDatasources": ["custom.alpine"],
+      "matchPackageNames": ["alpine_3_24/ipcalc", "alpine_3_24/networkmanager"],
+      "registryUrls": [
+        "https://dl-cdn.alpinelinux.org/alpine/v3.24/community/x86_64/"
+      ]
     },
     {
       "groupName": "App base image",


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Renovate's `repology` datasource stopped resolving Alpine package pins across the org: every `alpine_3_24/*` lookup returns `no-result` (the Dependency Dashboard shows "Repology lookup failed with unexpected error"), so Alpine pins are no longer updated at all. Repology rate limits its `tools/project-by` endpoint hard, and every run resolves all pins through it.

This replaces it with a `custom` datasource that reads the Alpine CDN directory listing directly, the same fix already landed on app-ssh in hassio-addons/app-ssh#1119:

- Adds a `custom.alpine` datasource pointing at `https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/` using the `html` format, so each `href` in the listing (`nginx-1.30.4-r1.apk`) becomes a version candidate.
- Switches the Alpine custom manager to `custom.alpine` and adds `extractVersionTemplate` to pull the version out of the filename. The leading `\d` in the pattern keeps a package from matching a longer sibling name (`nano` vs `nano-syntax-...`).
- Points the existing `matchDatasources` package rule at `custom.alpine`.
- Adds one rule listing the pins that live in the Alpine **community** repository (`ipcalc`, `networkmanager`) with a `registryUrls` override. Custom datasources use `registryStrategy: "first"`, so multiple registry URLs are not hunted and community packages would otherwise fail to resolve. That list is the only per-repo variable here; it was derived mechanically by diffing this addon's pins against the `main` and `community` APKINDEX files.

Verified locally with a Renovate dry run (`RENOVATE_PLATFORM=local RENOVATE_DRY_RUN=lookup`), since a green CI build proves nothing for this change: the Dockerfile is untouched, so buildx serves the `apk` layer from cache and no `apk add` runs.

- `renovate-config-validator` passes.
- All **9** pins in `tailscale/Dockerfile` extract and resolve: `bind-tools`, `coreutils`, `dnsmasq`, `ethtool`, `ipcalc`, `iproute2`, `iptables`, `networkmanager`, `nginx`.
- **Zero** lookup failures (`Found no results` count is 0), including the two community packages, which correctly pick up the community registry URL.
- No updates found: every pin already matches the newest version in the v3.24 APKINDEX, cross-checked against the index files directly. So nothing went stale while Repology was down, and no pin is currently blocking another PR in this repo.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Applies the same fix as hassio-addons/app-ssh#1119.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated Alpine package update detection using the Alpine v3.24 package repository.
  * Enabled automatic merging for eligible Alpine dependency updates.
  * Added support for resolving `ipcalc` and `networkmanager` from the Alpine community repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->