### PR TITLE
Write userspace_networking as a boolean, not a string

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
+++ b/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
@@ -108,7 +108,7 @@ if bashio::var.true "${invalid_dns_config}"; then
         "Please check your configuration based on the app's documentation under the \"DNS\" section"
     bashio::log.warning \
         "After the issue is fixed you can disable userspace_networking option again and restart the app"
-    bashio::app.option 'userspace_networking' 'true'
+    bashio::app.option 'userspace_networking' '^true'
 fi
 
 # MagicDNS related service dependencies:


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

`bashio::app.option` treats a value as raw JSON only when it starts with `^`, and as a plain string otherwise. The DNS fallback added in #662 was missing that prefix:

```bash
bashio::app.option 'userspace_networking' 'true'
```

so it wrote the **string** `"true"` into the app options, while `config.yaml` declares `userspace_networking: bool`:

```json
{"userspace_networking": "true"}
```

Every other setter in `stage2_hook.sh` already uses the raw-JSON form for non-string values (`share_on_port`, `taildrive`, `advertise_tags`), which is what made this one stand out. The remaining setters without `^` are correct as they are: `share_homeassistant` is a `list(disabled|serve|funnel)` so a string is right, and the others delete a key rather than set a value.

## Does it break anything today?

No, and that is why it has gone unnoticed. The Supervisor validates a `bool` option with `vol.Boolean()`, and `vol.Boolean()("true")` returns `True`, so the value is coerced and the option ends up correct.

It is still worth fixing:

- It relies on voluptuous coercing a wrong type rather than sending the right one.
- Since Bashio v0.18 the Supervisor API setters propagate failures, and this particular call is not wrapped in `bashio::try`. If that coercion ever tightened, the call would fail under `errexit` and abort `stage2_hook.sh`, so the app would fail to start for exactly the users #662 was written to rescue.
- It is inconsistent with the three neighbouring setters.

I deliberately did not wrap the call in `bashio::try`. The unwrapped form matches the other non-optional migrations in the file, and with the correct type there is nothing left to coerce.

## Verification

- Confirmed the current behaviour with the jq that `bashio::app.option` uses: `--arg` produces `{"userspace_networking":"true"}`, `--argjson` produces `{"userspace_networking":true}`.
- Confirmed `vol.Boolean()("true")` is `True`, so this is a correctness and consistency fix rather than a user-visible bug fix.
- Audited every `bashio::app.option` call in `stage2_hook.sh`; after this change each one uses the form matching its schema type.
- ShellCheck and `bash -n` clean.

Found while re-auditing the codebase for Bashio v0.19 compatibility after the merges of the last few hours. That audit was otherwise clean: all 47 `bashio::` symbols the app calls exist in v0.19, no deprecated `bashio::addon.*` aliases remain, the two dynamically constructed `bashio::network.${ip_version}_*` calls resolve to real functions, and the `subnet-routes-*` cache keys pass the key validation added in v0.18.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follows up on #662.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid DNS configurations by reliably recognizing enabled userspace networking settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->