### PR TITLE
⬆️ Update hassio-addons/workflows action to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,4 +18,4 @@ permissions:
 
 jobs:
   workflows:
-    uses: hassio-addons/workflows/.github/workflows/app-ci.yaml@c953d10f34dac22eb68c1cdedbbc4106a89bef88 # v3.0.1
+    uses: hassio-addons/workflows/.github/workflows/app-ci.yaml@e0c532a7b0fb264b3ff0c718c2c0308a0c8c1390 # v4.0.0

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,13 +19,13 @@ jobs:
       contents: read
       packages: read
       security-events: write
-    uses: hassio-addons/workflows/.github/workflows/app-ci.yaml@c953d10f34dac22eb68c1cdedbbc4106a89bef88 # v3.0.1
+    uses: hassio-addons/workflows/.github/workflows/app-ci.yaml@e0c532a7b0fb264b3ff0c718c2c0308a0c8c1390 # v4.0.0
 
   deploy:
     needs: ci
     permissions:
       contents: read
       packages: write
-    uses: hassio-addons/workflows/.github/workflows/app-deploy.yaml@c953d10f34dac22eb68c1cdedbbc4106a89bef88 # v3.0.1
+    uses: hassio-addons/workflows/.github/workflows/app-deploy.yaml@e0c532a7b0fb264b3ff0c718c2c0308a0c8c1390 # v4.0.0
     secrets:
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   workflows:
-    uses: hassio-addons/workflows/.github/workflows/labels.yaml@c953d10f34dac22eb68c1cdedbbc4106a89bef88 # v3.0.1
+    uses: hassio-addons/workflows/.github/workflows/labels.yaml@e0c532a7b0fb264b3ff0c718c2c0308a0c8c1390 # v4.0.0

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -14,4 +14,4 @@ permissions: {}
 
 jobs:
   workflows:
-    uses: hassio-addons/workflows/.github/workflows/pr-labels.yaml@c953d10f34dac22eb68c1cdedbbc4106a89bef88 # v3.0.1
+    uses: hassio-addons/workflows/.github/workflows/pr-labels.yaml@e0c532a7b0fb264b3ff0c718c2c0308a0c8c1390 # v4.0.0

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
   workflows:
-    uses: hassio-addons/workflows/.github/workflows/release-drafter.yaml@c953d10f34dac22eb68c1cdedbbc4106a89bef88 # v3.0.1
+    uses: hassio-addons/workflows/.github/workflows/release-drafter.yaml@e0c532a7b0fb264b3ff0c718c2c0308a0c8c1390 # v4.0.0

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/forwarding/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/forwarding/run
@@ -40,7 +40,11 @@ function get_forwardable_address() {
 function get_host_address() {
   local ip_version="${1}"
 
+  # The function name is composed from ip_version, and the address list is
+  # deliberately unquoted so it splits into one word per address
+  # shellcheck disable=SC2086
   if ! bashio::var.equals "$(bashio::network.${ip_version}_method)" "disabled"; then
+    # shellcheck disable=SC2086
     for address in $(bashio::network.${ip_version}_address); do
       if get_forwardable_address "${address}"; then
         break

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-egress-proxy/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-egress-proxy/finish
@@ -4,7 +4,8 @@
 # Home Assistant Community App: Tailscale
 # Take down the S6 supervision tree when MagicDNS egress proxy fails
 # ==============================================================================
-readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+readonly exit_code_container
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"
 readonly service="magicdns-egress-proxy"
@@ -17,7 +18,7 @@ bashio::log.info \
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
   if [[ "${exit_code_signal}" -ne 15 && "${exit_code_container}" -eq 0 ]]; then
-    echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
+    echo "$((128 + exit_code_signal))" > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-egress-proxy/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-egress-proxy/run
@@ -80,10 +80,10 @@ if bashio::var.equals "${MAGICDNS_MODE}" "RESTRICTED"; then
 
   # Forward everything to hassio DNS, except the black_list
   bashio::log.info "MagicDNS egress proxy: forwarding everything to ${hassio_dns_ipv4}${black_list:+, except:}"
-  options+=(--server=${hassio_dns_ipv4})
+  options+=("--server=${hassio_dns_ipv4}")
   for domain in "${black_list[@]}"; do
     bashio::log.info "  ${domain}"
-    options+=(--server=/${domain}/)
+    options+=("--server=/${domain}/")
   done
 elif bashio::var.equals "${MAGICDNS_MODE}" "UNRESTRICTED"; then
   # This means "Restricted" on egress side, ie. only domains in black-white-list are allowed
@@ -96,7 +96,7 @@ elif bashio::var.equals "${MAGICDNS_MODE}" "UNRESTRICTED"; then
   options+=(--address=/#/)
   for domain in "${white_list[@]}"; do
     bashio::log.info "  ${domain}"
-    options+=(--server=/${domain}/${hassio_dns_ipv4})
+    options+=("--server=/${domain}/${hassio_dns_ipv4}")
   done
 else
   bashio::exit.nok "Invalid MAGICDNS_MODE: '${MAGICDNS_MODE}'"

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-ingress-proxy/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-ingress-proxy/finish
@@ -4,7 +4,8 @@
 # Home Assistant Community App: Tailscale
 # Take down the S6 supervision tree when MagicDNS ingress proxy fails
 # ==============================================================================
-readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+readonly exit_code_container
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"
 readonly service="magicdns-ingress-proxy"
@@ -23,7 +24,7 @@ bashio::log.info \
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
   if [[ "${exit_code_signal}" -ne 15 && "${exit_code_container}" -eq 0 ]]; then
-    echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
+    echo "$((128 + exit_code_signal))" > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-ingress-proxy/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-ingress-proxy/run
@@ -61,17 +61,17 @@ fi
 
 # Listen addresses
 if bashio::var.has_value "${tailscale_address_ipv4-}"; then
-  options+=(--listen-address=${tailscale_address_ipv4})
+  options+=("--listen-address=${tailscale_address_ipv4}")
 fi
 if bashio::var.has_value "${tailscale_address_ipv6-}"; then
-  options+=(--listen-address=${tailscale_address_ipv6})
+  options+=("--listen-address=${tailscale_address_ipv6}")
 fi
 
 # on a non-lo interface this bind-dynamic option has the effect that dnsmasq connects only to the specified address
 # this is intentionally different from the egress proxy, where on the lo interface bind-interfaces option has the same effect
 # and on the lo interface bind-interfaces option doesn't result in a logged warning
 options+=(--bind-dynamic)
-options+=(--port=${dnsmasq_ingress_port})
+options+=("--port=${dnsmasq_ingress_port}")
 
 if bashio::var.equals "${MAGICDNS_MODE}" "RESTRICTED"; then
   # Only domains in black-white-list are allowed
@@ -84,7 +84,7 @@ if bashio::var.equals "${MAGICDNS_MODE}" "RESTRICTED"; then
   options+=(--address=/#/)
   for domain in "${white_list[@]}"; do
     bashio::log.info "  ${domain}"
-    options+=(--server=/${domain}/${MAGIC_DNS_IPV4})
+    options+=("--server=/${domain}/${MAGIC_DNS_IPV4}")
   done
 elif bashio::var.equals "${MAGICDNS_MODE}" "UNRESTRICTED"; then
   # Everything except domains in black-white-list are allowed
@@ -94,10 +94,10 @@ elif bashio::var.equals "${MAGICDNS_MODE}" "UNRESTRICTED"; then
 
   # Forward everything to MagicDNS, except the black_list
   bashio::log.info "MagicDNS ingress proxy: forwarding everything to ${MAGIC_DNS_IPV4}${black_list:+, except}"
-  options+=(--server=${MAGIC_DNS_IPV4})
+  options+=("--server=${MAGIC_DNS_IPV4}")
   for domain in "${black_list[@]}"; do
     bashio::log.info "  ${domain}"
-    options+=(--server=/${domain}/)
+    options+=("--server=/${domain}/")
   done
 else
   bashio::exit.nok "Invalid MAGICDNS_MODE: '${MAGICDNS_MODE}'"
@@ -112,7 +112,7 @@ if ! bashio::fs.file_exists "${MAGICDNS_INGRESS_PROXY_SUPPRESS_FORWARDING_CONFIG
   magicdns-ingress-proxy-forwarding setup forwarding "${dnsmasq_ingress_port}"
   magicdns-ingress-proxy-forwarding remove drop
 else
-  printf "${dnsmasq_ingress_port}" > "${DNSMASQ_INGRESS_PORT_LOCATION}"
+  printf '%s' "${dnsmasq_ingress_port}" > "${DNSMASQ_INGRESS_PORT_LOCATION}"
 fi
 
 # We need to delay the starting of the dependent services until iptables are configured

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-proxies-reconfigurator/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-proxies-reconfigurator/finish
@@ -4,7 +4,8 @@
 # Home Assistant Community App: Tailscale
 # Take down the S6 supervision tree when MagicDNS proxies reconfigurator fails
 # ==============================================================================
-readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+readonly exit_code_container
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"
 readonly service="magicdns-proxies-reconfigurator"
@@ -15,7 +16,7 @@ bashio::log.info \
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
   if [[ "${exit_code_signal}" -ne 15 && "${exit_code_container}" -eq 0 ]]; then
-    echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
+    echo "$((128 + exit_code_signal))" > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/finish
@@ -19,7 +19,9 @@ function remove_clamping() {
     | sed -nr 's/^.*?-o\s(\S+)\s.*$/\1/p')
   do
     bashio::log.info "Removing the MSS clamping for interface ${interface} (${ip_version})"
-    if ! ${cmd} -t mangle -D FORWARD -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}; then
+    # CLAMPING_IPTABLES_OPTIONS is a list of arguments and must word split
+    # shellcheck disable=SC2086
+    if ! ${cmd} -t mangle -D FORWARD -o "${interface}" ${CLAMPING_IPTABLES_OPTIONS}; then
       bashio::log.warning "Removing clamping is unsuccessful (${ip_version})"
     fi
   done

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
@@ -22,6 +22,8 @@ function setup_clamping() {
   then
     bashio::log.notice "Clamping is already set (${ip_version})"
   else
+    # CLAMPING_IPTABLES_OPTIONS is a list of arguments and must word split
+    # shellcheck disable=SC2086
     if ! ${cmd} -t mangle -A FORWARD -o ${TAILSCALE_INTERFACE} ${CLAMPING_IPTABLES_OPTIONS}; then
       bashio::log.warning "Setting up clamping is unsuccessful (${ip_version})"
     fi

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
@@ -4,7 +4,8 @@
 # Home Assistant Community App: Tailscale
 # Take down the S6 supervision tree when Nginx fails
 # ==============================================================================
-readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+readonly exit_code_container
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"
 readonly service="NGINX"
@@ -15,7 +16,7 @@ bashio::log.info \
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
   if [[ "${exit_code_signal}" -ne 15 && "${exit_code_container}" -eq 0 ]]; then
-    echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
+    echo "$((128 + exit_code_signal))" > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/nm-dispatcher-listener/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/nm-dispatcher-listener/finish
@@ -4,7 +4,8 @@
 # Home Assistant Community App: Tailscale
 # Take down the S6 supervision tree when nm-dispatcher-listener fails
 # ==============================================================================
-readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+readonly exit_code_container
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"
 readonly service="nm-dispatcher-listener"
@@ -20,7 +21,7 @@ bashio::log.info \
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
   if [[ "${exit_code_signal}" -ne 15 && "${exit_code_container}" -eq 0 ]]; then
-    echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
+    echo "$((128 + exit_code_signal))" > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/nm-dispatcher/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/nm-dispatcher/finish
@@ -4,7 +4,8 @@
 # Home Assistant Community App: Tailscale
 # Take down the S6 supervision tree when nm-dispatcher fails
 # ==============================================================================
-readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+readonly exit_code_container
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"
 readonly service="nm-dispatcher"
@@ -15,7 +16,7 @@ bashio::log.info \
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
   if [[ "${exit_code_signal}" -ne 15 && "${exit_code_container}" -eq 0 ]]; then
-    echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
+    echo "$((128 + exit_code_signal))" > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/services/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/services/run
@@ -55,6 +55,8 @@ if ! bashio::fs.file_exists "/data/services_import_is_done"; then
   bashio::log.info "Importing Tailscale Services configuration to the new services option..."
 
   # Filtering for non-importable services
+  # The jq program is single quoted on purpose so the shell does not expand it
+  # shellcheck disable=SC2016
   if non_importable_services=$(bashio::jq "${current_config}" '
     .Services // {} | to_entries[] | .key as $name | .value as $service
     | ($service.Web // {} | to_entries[] | (.key | split(":")[1]) as $port
@@ -77,6 +79,8 @@ if ! bashio::fs.file_exists "/data/services_import_is_done"; then
   fi
 
   # Filtering for importable services
+  # The jq program is single quoted on purpose so the shell does not expand it
+  # shellcheck disable=SC2016
   if importable_services=$(bashio::jq "${current_config}" '
     .Services // {} | to_entries[] | .key as $name | .value as $service
     | ($service.Web // {} | to_entries[] | (.key | split(":")[1]) as $port
@@ -92,6 +96,8 @@ if ! bashio::fs.file_exists "/data/services_import_is_done"; then
     jq -C <<<"${importable_services}"
 
     # Collect protocols for the service ports
+    # The jq program is single quoted on purpose so the shell does not expand it
+    # shellcheck disable=SC2016
     eval "declare -A service_protocols=($(bashio::jq "${current_config}" '
       .Services // {} | to_entries[] | .key as $name
       | .value.TCP | to_entries[] | .key as $port | (.value | has("TerminateTLS")) as $tls_terminated
@@ -137,6 +143,9 @@ if ! bashio::fs.file_exists "/data/services_import_is_done"; then
       fi
       service_config="$(bashio::var.json "${service_config_args[@]}")"
 
+      # The right hand side is quoted on purpose: the space padded values are
+      # compared literally, which is what makes this set membership check correct
+      # shellcheck disable=SC2076
       if [[ " ${configured_services[*]} " =~ " ${service_config} " ]]; then
         bashio::log.notice \
           "Service host configuration for ${service_name} (${target}, ${protocol}, ${port}${path:+, $path})" \
@@ -198,6 +207,9 @@ readarray -t current_names < <( \
 # Remove services that are no longer configured in this app
 # current_names \ configured_names
 for service_name in "${current_names[@]}"; do
+  # The right hand side is quoted on purpose: the space padded values are
+  # compared literally, which is what makes this set membership check correct
+  # shellcheck disable=SC2076
   if ! [[ " ${configured_names[*]} " =~ " ${service_name} " ]]; then
     bashio::log.info "Removing stale service host configuration for ${service_name}"
     drain_and_clear_service "${service_name}"
@@ -207,6 +219,9 @@ done
 # Clean any existing configuration for this service before reconfiguring
 # current_names ⋂ configured_names
 for service_name in "${configured_names[@]}"; do
+  # The right hand side is quoted on purpose: the space padded values are
+  # compared literally, which is what makes this set membership check correct
+  # shellcheck disable=SC2076
   if [[ " ${current_names[*]} " =~ " ${service_name} " ]]; then
     drain_and_clear_service "${service_name}"
   fi

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/share-homeassistant/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/share-homeassistant/finish
@@ -4,7 +4,8 @@
 # Home Assistant Community App: Tailscale
 # Take down the S6 supervision tree when share-homeassistant fails
 # ==============================================================================
-readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+readonly exit_code_container
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"
 readonly service="share-homeassistant"
@@ -15,7 +16,7 @@ bashio::log.info \
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
   if [[ "${exit_code_signal}" -ne 15 && "${exit_code_container}" -eq 0 ]]; then
-    echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
+    echo "$((128 + exit_code_signal))" > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/taildrop/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/taildrop/finish
@@ -4,7 +4,8 @@
 # Home Assistant Community App: Tailscale
 # Take down the S6 supervision tree when Taildrop fails
 # ==============================================================================
-readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+readonly exit_code_container
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"
 readonly service="taildrop"
@@ -15,7 +16,7 @@ bashio::log.info \
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
   if [[ "${exit_code_signal}" -ne 15 && "${exit_code_container}" -eq 0 ]]; then
-    echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
+    echo "$((128 + exit_code_signal))" > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/finish
@@ -4,7 +4,8 @@
 # Home Assistant Community App: Tailscale
 # Take down the S6 supervision tree when Tailscale fails
 # ==============================================================================
-readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+readonly exit_code_container
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"
 readonly service="tailscaled"
@@ -15,7 +16,7 @@ bashio::log.info \
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
   if [[ "${exit_code_signal}" -ne 15 && "${exit_code_container}" -eq 0 ]]; then
-    echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
+    echo "$((128 + exit_code_signal))" > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -24,7 +24,7 @@ fi
 # Use configured UDP port
 udp_port=$(bashio::app.port "41641/udp")
 if bashio::var.has_value "${udp_port}"; then
-  options+=(--port=${udp_port})
+  options+=("--port=${udp_port}")
 fi
 
 # Use userspace networking when explicitly enabled
@@ -55,7 +55,7 @@ if ! bashio::fs.file_exists "/etc/resolv.for-tailscaled.conf"; then
 else
   # Using fake resolv.conf
   bashio::log.info "Using dnsmasq as upstream DNS server for tailscaled"
-  bashio::net.wait_for 53 $(awk '{ print $2 }' < /etc/resolv.for-tailscaled.conf)
+  bashio::net.wait_for 53 "$(awk '{ print $2 }' < /etc/resolv.for-tailscaled.conf)"
   if bashio::debug ; then
     exec unshare -m bash -c "mount --bind /etc/resolv.for-tailscaled.conf /etc/resolv.conf; exec /opt/tailscaled $(printf "\"%s\" " "${options[@]}")"
   else

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/web/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/web/finish
@@ -4,7 +4,8 @@
 # Home Assistant Community App: Tailscale
 # Take down the S6 supervision tree when Tailscale web fails
 # ==============================================================================
-readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
+readonly exit_code_container
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"
 readonly service="Tailscale web"
@@ -15,7 +16,7 @@ bashio::log.info \
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
   if [[ "${exit_code_signal}" -ne 15 && "${exit_code_container}" -eq 0 ]]; then
-    echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
+    echo "$((128 + exit_code_signal))" > /run/s6-linux-init-container-results/exitcode
   fi
   [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then

--- a/tailscale/rootfs/usr/bin/healthcheck
+++ b/tailscale/rootfs/usr/bin/healthcheck
@@ -26,7 +26,7 @@ declare backend_state is_self_online
 if ! bashio::var.has_value "${STARTED_TIMESTAMP-}"
 then
   STARTED_TIMESTAMP=$(date +"%s")
-  printf "${STARTED_TIMESTAMP}" > /var/run/s6/container_environment/STARTED_TIMESTAMP
+  printf '%s' "${STARTED_TIMESTAMP}" > /var/run/s6/container_environment/STARTED_TIMESTAMP
 fi
 
 if status_json=$(/opt/tailscale status --json --self=true --peers=false 2> /dev/null); then
@@ -38,14 +38,14 @@ if bashio::var.equals "${backend_state-}" "Running" && bashio::var.true "${is_se
   ! bashio::var.equals "${MAGICDNS_PROXIES_RECONFIGURATOR_HEALTH_STATE-}" 'UNHEALTHY'
 then
   LAST_ONLINE_TIMESTAMP=$(date +"%s")
-  printf "${LAST_ONLINE_TIMESTAMP}" > /var/run/s6/container_environment/LAST_ONLINE_TIMESTAMP
+  printf '%s' "${LAST_ONLINE_TIMESTAMP}" > /var/run/s6/container_environment/LAST_ONLINE_TIMESTAMP
 fi
 
 if [[ "${backend_state-}" == "Stopped" ]] || \
   (bashio::var.has_value "${LAST_ONLINE_TIMESTAMP-}" && \
-    (( $(date +"%s") - ${LAST_ONLINE_TIMESTAMP} > ${HEALTHCHECK_OFFLINE_TIMEOUT} )) ) || \
+    (( $(date +"%s") - LAST_ONLINE_TIMESTAMP > HEALTHCHECK_OFFLINE_TIMEOUT )) ) || \
   (! bashio::var.has_value "${LAST_ONLINE_TIMESTAMP-}" && \
-    (( $(date +"%s") - ${STARTED_TIMESTAMP} > ${HEALTHCHECK_RESTART_TIMEOUT} )) )
+    (( $(date +"%s") - STARTED_TIMESTAMP > HEALTHCHECK_RESTART_TIMEOUT )) )
 then
   # Unhealthy
   bashio::exit.nok


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Updates the reusable workflows to v4.0.0 and fixes everything the new Shellcheck coverage surfaces.

v4.0.0 is a breaking release: hassio-addons/workflows#329 makes the Shellcheck job actually scan S6 service scripts. Until now they were silently skipped, because `ludeeus/action-shellcheck` discovers extensionless files by matching their first line against `^#! */[^ ]*/(env *)?[abk]*sh`, and `#!/command/with-contenv bashio` matches neither that nor any recognised filename pattern.

On this repository that meant **7 of 45 shell files were scanned and 38 were skipped**, roughly 2000 of our 2600 lines of shell, even though every one of those scripts carries a `# shellcheck shell=bash` directive. With v4.0.0 the same repository scans 43 of 45.

That surfaced 51 findings, all fixed here.

## Fixed for real (40)

- **`SC2155` (10)** `readonly exit_code_container=$(<...)` split into assignment and `readonly`, in all ten longrun `finish` scripts. All ten were the same line, duplicated.
- **`SC2004` (14)** Dropped the unnecessary `$` on arithmetic variables, ten in the `finish` scripts and four in `healthcheck`.
- **`SC2206` (12)** and **`SC2046` (1)** Quoted `options+=(--flag=${var})` appends and one command substitution. Every one of these values is an IP address, a port or a domain name, so quoting is behaviour neutral; they were single element appends that never needed to word split.
- **`SC2059` (3)** `printf "${VAR}"` became `printf '%s' "${VAR}"`, so a value containing a `%` can no longer be interpreted as a format string.

## Deliberately suppressed, with a comment explaining why (11)

These are cases where following Shellcheck's advice would break the code, so each gets a targeted `disable` and a note rather than a change:

- **`SC2016` (3)** in `services/run`. Single quoted jq programs that must not be expanded by the shell.
- **`SC2076` (3)** in `services/run`. The right hand sides of `[[ ... =~ ... ]]` are quoted on purpose. Quoting makes bash compare literally, and combined with the space padding that is exactly what makes the set membership checks correct. Removing the quotes, as Shellcheck suggests, would turn the needle into a regex and break them.
- **`SC2086` (5)** in `mss-clamping` and `forwarding`. `CLAMPING_IPTABLES_OPTIONS` is a list of arguments that must word split, the address list in `forwarding/run` must split into one word per address, and `bashio::network.${ip_version}_method` builds a function name from a variable so it cannot be quoted at all. `${interface}` was genuinely unsafe and is now quoted.

## Verification

- Shellcheck reports **0 findings** over the exact file set v4.0.0 scans, simulated locally with the action's own `find` patterns.
- `bash -n` passes on all 18 changed scripts.
- Checked that splitting `readonly x=$(<file)` does not change behaviour under `errexit`: both the old and the new form abort identically when the file is missing, so the `finish` scripts behave the same.
- Before pushing the fixes, CI on this branch reported exactly the 51 findings predicted locally, code for code, which confirms the local simulation matches the real job.

Two files remain undiscovered even with v4.0.0, and neither is a problem: `rootfs/command/with-contenv-merge` is an execline script and correctly not linted as bash, and `rootfs/etc/NetworkManager/dispatcher.d/protect-subnets` has an app specific filename and an unrecognised shebang, so it matches no discovery rule.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Depends on hassio-addons/workflows#329, released in v4.0.0.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
