### PR TITLE
Point the AppArmor profile at the S6 v3 service paths

### DIFF
--- a/tailscale/apparmor.txt
+++ b/tailscale/apparmor.txt
@@ -14,9 +14,7 @@ profile tailscale flags=(attach_disconnected,mediate_deleted) {
   /run/{s6,s6-rc*,service}/** ix,
   /package/** ix,
   /command/** ix,
-  /etc/services.d/** rwix,
-  /etc/cont-init.d/** rwix,
-  /etc/cont-finish.d/** rwix,
+  /etc/s6-overlay/** rwix,
   /run/{,**} rwk,
   /dev/tty rw,
 


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The AppArmor profile still grants access to S6-Overlay **v2** directories:

```
/etc/services.d/** rwix,
/etc/cont-init.d/** rwix,
/etc/cont-finish.d/** rwix,
```

This app migrated to S6-Overlay v3 in March 2023, in #156. None of those three directories exist in the base image any more, and this repository has no content in them, so all three rules have been dead for over three years. Meanwhile `/etc/s6-overlay`, where the 36 executable service scripts actually live, has no rule of its own at all.

This replaces the three dead v2 rules with the v3 equivalent, which is what they were meant to express.

## Risk

None that I can see, in either direction:

- The three removed rules cover paths that do not exist, so removing them cannot take away a permission anything relies on.
- The added rule grants access rather than restricting it, so it cannot make the profile stricter.

## Verification

- Confirmed against the base image (`ghcr.io/hassio-addons/base/amd64:21.0.2`) that `/etc/services.d`, `/etc/cont-init.d` and `/etc/cont-finish.d` are absent, while `/etc/s6-overlay` is present.
- Confirmed this repository's rootfs has no `etc/services.d`, `etc/cont-init.d` or `etc/cont-finish.d` directory; all S6 content is under `etc/s6-overlay/s6-rc.d` and `etc/s6-overlay/scripts`.
- Ran the real `apparmor_parser -Q -K` over the changed profile, which parses it including the `tunables/global` and `abstractions/base` includes. It parses cleanly.

## Does S6 recreate those directories at runtime?

No, and worth spelling out because it is the obvious objection. S6-Overlay's legacy compatibility layer only ever **reads** those paths, and when it copies, it copies out of them rather than into them.

`cont-init` iterates and executes, and never creates anything:

```sh
for file in `s6-ls "$etc/cont-init.d" 2>/dev/null | s6-sort` ; do
  "$etc/cont-init.d/$file"
```

The `2>/dev/null` is what makes a missing directory a silent no-op.

`services-up` copies legacy longruns **from** `/etc/services.d` **to** `/run`:

```sh
dir=/run/s6/legacy-services
s6-hiercopy "$etc/services.d/$i" "$dir/$i"
s6-ln -nsf "$dir/$file" "/run/service/$file"
```

Confirmed empirically as well, in a container where `/init` runs to completion so both `cont-init` and `services-up` have executed: all three directories are still absent.

Should legacy services ever be added to this app, they would execute from `/run/s6/legacy-services` and `/run/service`, both of which the profile already covers through `/run/{s6,s6-rc*,service}/** ix,` and `/run/{,**} rwk,`. So the profile stays correct in that case too.

## Noted, but deliberately not changed here

Line 7 of the profile is a bare `file,` rule, which grants all file access. That means most of the specific path rules below it, including the one this PR fixes, are effectively redundant today, and the profile confines considerably less than its length suggests. Tightening that is a much larger change with a real risk of preventing the app from starting, so it does not belong in a cleanup PR. Worth a separate look if profile hardening is ever on the table.

Also worth knowing for that future look: `/opt/tailscale` and `/opt/tailscaled` are executed by the service scripts and have no rule of their own either, so they too currently depend on `file,`.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follows up on #156, which migrated this app to S6-Overlay v3.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
