### PR TITLE
Add default values as comment to the example configuration

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -58,21 +58,21 @@ accept_dns: true
 accept_routes: false
 advertise_connector: false
 advertise_exit_node: false
-advertise_routes:
+advertise_routes:                       # the default is [] (an empty list), here are some example:
   - local_subnets
   - 192.168.1.0/24
   - fd12:3456:abcd::/64
-advertise_tags:
+advertise_tags:                         # the default is [] (an empty list), here are some example:
   - tag:example
   - tag:homeassistant
 always_use_derp: false
-exit_node: 100.101.102.103
+exit_node: 100.101.102.103              # this is optional, ie. by default this is missing
 log_level: info
 log_upload: false
 login_server: "https://controlplane.tailscale.com"
 share_homeassistant: disabled
 share_on_port: 443
-services:
+services:                               # the default is [] (an empty list), here are some example:
   - name: svc:audiobookshelf
     target: http://127.0.0.1:13378
     protocol: http

--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -53,6 +53,7 @@ https://console.tailscale.com/
 **Note:** _This is just an example, not even the default, don't copy and paste
 it! Create your own!_
 
+<!-- prettier-ignore -->
 ```yaml
 accept_dns: true
 accept_routes: false

--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -59,21 +59,21 @@ accept_dns: true
 accept_routes: false
 advertise_connector: false
 advertise_exit_node: false
-advertise_routes:                       # the default is [] (an empty list), here are some example:
+advertise_routes:                       # the default is [] (an empty list), here are some examples:
   - local_subnets
   - 192.168.1.0/24
   - fd12:3456:abcd::/64
-advertise_tags:                         # the default is [] (an empty list), here are some example:
+advertise_tags:                         # the default is [] (an empty list), here are some examples:
   - tag:example
   - tag:homeassistant
 always_use_derp: false
-exit_node: 100.101.102.103              # this is optional, ie. by default this is missing
+exit_node: 100.101.102.103              # this is optional, i.e. it is missing by default
 log_level: info
 log_upload: false
 login_server: "https://controlplane.tailscale.com"
 share_homeassistant: disabled
 share_on_port: 443
-services:                               # the default is [] (an empty list), here are some example:
+services:                               # the default is [] (an empty list), here are some examples:
   - name: svc:audiobookshelf
     target: http://127.0.0.1:13378
     protocol: http


### PR DESCRIPTION
# Proposed Changes

Some users still copy and paste the example and complain it doesn't work. Adding comment to the yaml is harmless, after "Save", they will disappear.

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the sample configuration documentation to preserve the intended formatting of the YAML example.
  * Clarified wording in comments for advertised routes, advertised tags, services, and exit-node settings.
  * Removed the `local_subnets` entry from the advertised-routes example and its related explanatory text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->