### PR TITLE
Migrate log_level to log_suppression option

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -67,7 +67,7 @@ advertise_tags:
   - tag:homeassistant
 always_use_derp: false
 exit_node: 100.101.102.103
-log_level: info
+log_suppression: true
 log_upload: false
 login_server: "https://controlplane.tailscale.com"
 share_homeassistant: disabled
@@ -224,29 +224,15 @@ section of this documentation.
 **Note:** The `exit-node-allow-lan-access` option is always enabled when an exit
 node is specified. This is required by the Home Assistant environment.
 
-### Option: `log_level`
+### Option: `log_suppression`
 
-Optionally enable all tailscaled debug messages in the app's log. Turn it on only
-in case you are troubleshooting, because Tailscale's daemon is quite chatty. If
-`log_level` is set to `info` or less severe level, tailscaled logs will be
-suppressed after 200 lines.
+This option allows you to suppress Tailscale's daemon debug log messages in the
+app's log after 200 lines.
 
-The `log_level` option controls the level of log output by the app and can
-be changed to be more or less verbose, which might be useful when you are
-dealing with an unknown issue. Possible values are:
+Turn it off only in case you are troubleshooting, because Tailscale's daemon is
+quite chatty.
 
-- `trace`: Show every detail, like all called internal functions.
-- `debug`: Shows detailed debug information.
-- `info`: Normal (usually) interesting events.
-- `notice`: Normal but significant events.
-- `warning`: Exceptional occurrences that are not errors.
-- `error`: Runtime errors that do not require immediate action.
-- `fatal`: Something went terribly wrong. App becomes unusable.
-
-Please note that each level automatically includes log messages from a
-more severe level, e.g., `debug` also shows `info` messages. By default,
-the `log_level` is set to `info`, which is the recommended setting unless
-you are troubleshooting.
+This option is enabled by default.
 
 ### Option: `log_upload`
 

--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -226,11 +226,11 @@ node is specified. This is required by the Home Assistant environment.
 
 ### Option: `log_suppression`
 
-This option allows you to suppress Tailscale's daemon debug log messages in the
-app's log after 200 lines.
+This option allows you to suppress Tailscale's log messages in the app's log
+after 200 lines.
 
-Turn it off only in case you are troubleshooting, because Tailscale's daemon is
-quite chatty.
+Turn it off only in case you are troubleshooting, because Tailscale is quite
+chatty.
 
 This option is enabled by default.
 

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -48,7 +48,7 @@ options:
   advertise_routes: []
   advertise_tags: []
   always_use_derp: false
-  log_level: info
+  log_suppression: true
   log_upload: false
   login_server: "https://controlplane.tailscale.com"
   share_homeassistant: disabled
@@ -77,7 +77,7 @@ schema:
     - "match(^tag:[a-zA-Z][a-zA-Z0-9-]*$)"
   always_use_derp: bool
   exit_node: "match(^(?:(?:(?:25[0-5]|(?:2[0-4]|1\\d|[1-9]?)\\d)\\.){3}(?:25[0-5]|(?:2[0-4]|1\\d|[1-9]?)\\d)|[a-fA-F\\d.:]+:[a-fA-F\\d.:]+|[a-fA-F\\d]{8}(?:-[a-fA-F\\d]{4}){3}-[a-fA-F\\d]{12}|auto:any)$)?"
-  log_level: list(trace|debug|info|notice|warning|error|fatal)
+  log_suppression: bool
   log_upload: bool
   login_server: url
   share_homeassistant: list(disabled|serve|funnel)

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-egress-proxy/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-egress-proxy/run
@@ -102,11 +102,6 @@ else
   bashio::exit.nok "Invalid MAGICDNS_MODE: '${MAGICDNS_MODE}'"
 fi
 
-if bashio::trace; then
-  options+=(--log-queries)
-  options+=(--log-debug)
-fi
-
 magicdns-egress-proxy-forwarding setup forwarding "${dnsmasq_egress_port}"
 
 if ! bashio::fs.file_exists "/etc/resolv.for-tailscaled.conf"; then

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-ingress-proxy/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/magicdns-ingress-proxy/run
@@ -103,11 +103,6 @@ else
   bashio::exit.nok "Invalid MAGICDNS_MODE: '${MAGICDNS_MODE}'"
 fi
 
-if bashio::trace; then
-  options+=(--log-queries)
-  options+=(--log-debug)
-fi
-
 if ! bashio::fs.file_exists "${MAGICDNS_INGRESS_PROXY_SUPPRESS_FORWARDING_CONFIGURATION_LOCATION}"; then
   magicdns-ingress-proxy-forwarding setup forwarding "${dnsmasq_ingress_port}"
   magicdns-ingress-proxy-forwarding remove drop

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -5,10 +5,8 @@
 # Runs tailscale
 # ==============================================================================
 
-readonly TAILSCALED_LOGLEVEL_NOTICE="Tailscale logs will be suppressed after 200 lines, set app's configuration option 'log_level' to 'debug' to see further logs"
-readonly TAILSCALED_LOGLEVEL_MESSAGE="[further tailscaled logs suppressed, set app's configuration option 'log_level' to 'debug' to see further tailscaled logs]"
-
-declare -a options
+declare -a options=()
+declare -a sed_options=()
 declare udp_port
 
 bashio::log.info 'Starting Tailscale...'
@@ -38,31 +36,35 @@ if bashio::config.true "always_use_derp"; then
   bashio::log.notice "You have enabled always_use_derp, all traffic will be routed via DERP servers"
 fi
 
+# Configure sed for log supression
+if bashio::config.true 'log_suppression'; then
+  bashio::log.notice \
+    "Tailscale logs will be suppressed after 200 lines, set app's configuration option 'log_suppression' to 'false' to see further logs"
+  sed_options+=('-e')
+  sed_options+=('1,200p')
+  sed_options+=('-e')
+  sed_options+=("201c[further tailscaled logs suppressed, set app's configuration option 'log_suppression' to 'false' to see further tailscaled logs]")
+fi
+
 # Run Tailscale
 # If exists, resolv.dnsmasq.conf pointing to the dummy dnsmasq will be mounted in place of the real resolv.conf only for tailscaled
 # This will prevent the DNS at 100.100.100.100 to call back to hassio_dns causing a loop
 if ! bashio::fs.file_exists "/etc/resolv.for-tailscaled.conf"; then
   # Running the regular way, no resolv.conf replacement
-  if bashio::debug ; then
+  if bashio::config.false 'log_suppression' ; then
     exec /opt/tailscaled "${options[@]}"
   else
-    bashio::log.notice "${TAILSCALED_LOGLEVEL_NOTICE}"
-    /opt/tailscaled "${options[@]}" 2>&1 \
-      | stdbuf -i0 -oL -eL \
-        sed -n -e '1,200p' \
-          -e "201c${TAILSCALED_LOGLEVEL_MESSAGE}"
+    /opt/tailscaled "${options[@]}" \
+      2> >(stdbuf -i0 -oL -eL sed -nE "${sed_options[@]}")
   fi
 else
   # Using fake resolv.conf
   bashio::log.info "Using dnsmasq as upstream DNS server for tailscaled"
   bashio::net.wait_for 53 "$(awk '{ print $2 }' < /etc/resolv.for-tailscaled.conf)"
-  if bashio::debug ; then
+  if bashio::config.false 'log_suppression' ; then
     exec unshare -m bash -c "mount --bind /etc/resolv.for-tailscaled.conf /etc/resolv.conf; exec /opt/tailscaled $(printf "\"%s\" " "${options[@]}")"
   else
-    bashio::log.notice "${TAILSCALED_LOGLEVEL_NOTICE}"
-    unshare -m bash -c "mount --bind /etc/resolv.for-tailscaled.conf /etc/resolv.conf; exec /opt/tailscaled $(printf "\"%s\" " "${options[@]}") 2>&1" \
-      | stdbuf -i0 -oL -eL \
-        sed -n -e '1,200p' \
-          -e "201c${TAILSCALED_LOGLEVEL_MESSAGE}"
+    unshare -m bash -c "mount --bind /etc/resolv.for-tailscaled.conf /etc/resolv.conf; exec /opt/tailscaled $(printf "\"%s\" " "${options[@]}")" \
+      2> >(stdbuf -i0 -oL -eL sed -nE "${sed_options[@]}")
   fi
 fi

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -39,12 +39,12 @@ fi
 # Configure awk for log supression
 if bashio::config.true 'log_suppression'; then
   bashio::log.notice \
-    "Tailscale's log messages will be suppressed after 200 lines, set app's configuration option \"log_suppression\" to \"false\" to see further logs"
+    "Tailscale's log messages will be suppressed after 200 lines, set the app's configuration option \"log_suppression\" to \"false\" to see further logs"
   awk_program='
     NR<=200 {print}
     NR==201 {system("bash -c \"
       source /usr/lib/bashio/bashio.sh;
-      bashio::log.notice \\\"Further Tailscale log messages are suppressed, set apps configuration option \\\\\\\"log_suppression\\\\\\\" to \\\\\\\"false\\\\\\\" to see further logs\\\" \" ")}'
+      bashio::log.notice \\\"Further Tailscale log messages are suppressed, set the app'"'"'s configuration option \\\\\\\"log_suppression\\\\\\\" to \\\\\\\"false\\\\\\\" to see further logs\\\" \" ")}'
   awk_program="${awk_program//$'\n'/}"
 fi
 

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -56,7 +56,7 @@ if ! bashio::fs.file_exists "/etc/resolv.for-tailscaled.conf"; then
   if bashio::config.false 'log_suppression' ; then
     exec /opt/tailscaled "${options[@]}"
   else
-    /opt/tailscaled "${options[@]}" \
+    exec /opt/tailscaled "${options[@]}" \
       2> >(stdbuf -i0 -oL -eL awk -F $'\n' -e "${awk_program}")
   fi
 else
@@ -66,7 +66,7 @@ else
   if bashio::config.false 'log_suppression' ; then
     exec unshare -m bash -c "mount --bind /etc/resolv.for-tailscaled.conf /etc/resolv.conf; exec /opt/tailscaled $(printf "\"%s\" " "${options[@]}")"
   else
-    unshare -m bash -c "mount --bind /etc/resolv.for-tailscaled.conf /etc/resolv.conf; exec /opt/tailscaled $(printf "\"%s\" " "${options[@]}")" \
+    exec unshare -m bash -c "mount --bind /etc/resolv.for-tailscaled.conf /etc/resolv.conf; exec /opt/tailscaled $(printf "\"%s\" " "${options[@]}")" \
       2> >(stdbuf -i0 -oL -eL awk -F $'\n' -e "${awk_program}")
   fi
 fi

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -5,8 +5,8 @@
 # Runs tailscale
 # ==============================================================================
 
-declare -a options=()
-declare -a sed_options=()
+declare -a options
+declare awk_program
 declare udp_port
 
 bashio::log.info 'Starting Tailscale...'
@@ -36,14 +36,13 @@ if bashio::config.true "always_use_derp"; then
   bashio::log.notice "You have enabled always_use_derp, all traffic will be routed via DERP servers"
 fi
 
-# Configure sed for log supression
+# Configure awk for log supression
 if bashio::config.true 'log_suppression'; then
   bashio::log.notice \
-    "Tailscale logs will be suppressed after 200 lines, set app's configuration option 'log_suppression' to 'false' to see further logs"
-  sed_options+=('-e')
-  sed_options+=('1,200p')
-  sed_options+=('-e')
-  sed_options+=("201c[further tailscaled logs suppressed, set app's configuration option 'log_suppression' to 'false' to see further tailscaled logs]")
+    "Tailscale's log messages will be suppressed after 200 lines, set app's configuration option \"log_suppression\" to \"false\" to see further logs"
+  awk_program='
+    NR<=200 {print}
+    NR==201 {system("bash -c \". /usr/lib/bashio/bashio.sh; bashio::log.notice \\\"Further Tailscale log messages are suppressed, set apps configuration option \\\\\\\"log_suppression\\\\\\\" to \\\\\\\"false\\\\\\\" to see further logs\\\" \" ")}'
 fi
 
 # Run Tailscale
@@ -55,7 +54,7 @@ if ! bashio::fs.file_exists "/etc/resolv.for-tailscaled.conf"; then
     exec /opt/tailscaled "${options[@]}"
   else
     /opt/tailscaled "${options[@]}" \
-      2> >(stdbuf -i0 -oL -eL sed -nE "${sed_options[@]}")
+      2> >(stdbuf -i0 -oL -eL awk -F $'\n' -e "${awk_program}")
   fi
 else
   # Using fake resolv.conf
@@ -65,6 +64,6 @@ else
     exec unshare -m bash -c "mount --bind /etc/resolv.for-tailscaled.conf /etc/resolv.conf; exec /opt/tailscaled $(printf "\"%s\" " "${options[@]}")"
   else
     unshare -m bash -c "mount --bind /etc/resolv.for-tailscaled.conf /etc/resolv.conf; exec /opt/tailscaled $(printf "\"%s\" " "${options[@]}")" \
-      2> >(stdbuf -i0 -oL -eL sed -nE "${sed_options[@]}")
+      2> >(stdbuf -i0 -oL -eL awk -F $'\n' -e "${awk_program}")
   fi
 fi

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -42,7 +42,10 @@ if bashio::config.true 'log_suppression'; then
     "Tailscale's log messages will be suppressed after 200 lines, set app's configuration option \"log_suppression\" to \"false\" to see further logs"
   awk_program='
     NR<=200 {print}
-    NR==201 {system("bash -c \". /usr/lib/bashio/bashio.sh; bashio::log.notice \\\"Further Tailscale log messages are suppressed, set apps configuration option \\\\\\\"log_suppression\\\\\\\" to \\\\\\\"false\\\\\\\" to see further logs\\\" \" ")}'
+    NR==201 {system("bash -c \"
+      source /usr/lib/bashio/bashio.sh;
+      bashio::log.notice \\\"Further Tailscale log messages are suppressed, set apps configuration option \\\\\\\"log_suppression\\\\\\\" to \\\\\\\"false\\\\\\\" to see further logs\\\" \" ")}'
+  awk_program="${awk_program//$'\n'/}"
 fi
 
 # Run Tailscale

--- a/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
+++ b/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
@@ -10,6 +10,7 @@ declare proxy funnel proxy_and_funnel_port
 declare tags
 declare taildrive_addons taildrive_config
 declare share_service_name
+declare log_level log_suppression
 
 readonly MAGIC_DNS_IPV4="100.100.100.100"
 readonly MAGIC_DNS_IPV6="fd7a:115c:a1e0::53"
@@ -86,6 +87,22 @@ share_service_name=$(bashio::jq "${options}" '.share_service_name | select(.!=nu
 if bashio::var.has_value "${share_service_name}"; then
     bashio::log.info 'Removing deprecated share_service_name option'
     bashio::app.option 'share_service_name'
+fi
+
+# Migrate log_level to log_suppression
+log_level=$(bashio::jq "${options}" '.log_level | select(.!=null)')
+if bashio::var.has_value "${log_level}"; then
+    if bashio::var.equals "${log_level}" 'debug' || \
+        bashio::var.equals "${log_level}" 'trace'
+    then
+        log_suppression="false"
+    else
+        log_suppression="true"
+    fi
+    bashio::app.option 'log_suppression' "^${log_suppression}"
+    bashio::log.info "Successfully migrated log_level option \"${log_level}\" to log_suppression \"${log_suppression}\""
+    bashio::log.info 'Removing deprecated log_level option'
+    bashio::app.option 'log_level'
 fi
 
 # Check DNS configuration

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -53,11 +53,14 @@ configuration:
       By setting a device on your network as an exit node, you can use it to
       route all your public internet traffic as needed, like a consumer VPN.
       This option is unused by default.
-  log_level:
-    name: Log level
+  log_suppression:
+    name: Log suppression
     description: >-
-      Controls the level of log details the app provides.
-      This only applies to the app itself, not Tailscale.
+      This option allows you to suppress Tailscale's daemon debug log messages in the
+      app's log after 200 lines.
+      Turn it off only in case you are troubleshooting, because Tailscale's daemon is
+      quite chatty.
+      This option is enabled by default.
   log_upload:
     name: Log upload
     description: >-

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -56,10 +56,10 @@ configuration:
   log_suppression:
     name: Log suppression
     description: >-
-      This option allows you to suppress Tailscale's daemon debug log messages in the
-      app's log after 200 lines.
-      Turn it off only in case you are troubleshooting, because Tailscale's daemon is
-      quite chatty.
+      This option allows you to suppress Tailscale's log messages in the app's log
+      after 200 lines.
+      Turn it off only in case you are troubleshooting, because Tailscale is quite
+      chatty.
       This option is enabled by default.
   log_upload:
     name: Log upload


### PR DESCRIPTION
# Proposed Changes

The `log_level` was a mess, setting it to debug to get the normal TS logs unlimited is non-intuitive at least.

And debug level added unnecessary app debug logs as noise to it.

New `log_supression` enables/disables whether TS logs are unlimited, nothing more.

Config is migrated automatically.

## Related Issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Replaced the previous log-level setting with log suppression, enabled by default and limiting Tailscale messages after 200 lines.
  * Existing log-level settings are automatically migrated to the new configuration.

* **Bug Fixes**
  * Reduced verbose DNS proxy debug logging.
  * Applied consistent log suppression across standard and alternate DNS execution paths.

* **Documentation**
  * Updated configuration examples, descriptions, and translations to explain the log suppression setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->