### PR TITLE
Migrate advertise_routes option, replace "local_subnets" with the actual values

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -59,7 +59,6 @@ accept_routes: false
 advertise_connector: false
 advertise_exit_node: false
 advertise_routes:
-  - local_subnets
   - 192.168.1.0/24
   - fd12:3456:abcd::/64
 advertise_tags:
@@ -166,9 +165,6 @@ your device is connected to) to other clients on your tailnet.
 
 By adding to the list the IP addresses and masks of the subnet routes, you can
 use it to make your devices on these subnets accessible within your tailnet.
-
-By adding `local_subnets` to the list, the app will advertise routes to your
-subnets on all supported interfaces.
 
 More information: [Subnet routers][tailscale_info_subnets]
 

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/local-network/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/local-network/run
@@ -4,26 +4,4 @@
 # Wait for the local network (default HA interface) to be ready
 # ==============================================================================
 
-readonly WAIT_DELAY=5   # 5s
-readonly WAIT_COUNT=60  # 60*5s = 300s = 5m
-
-declare wait_counter=0
-
-# Some services need a working local network to function properly.
-# They can mark this service as dependency, and wait for the successful startup.
-
-# Until HA has no default interface, we wait a little
-while ! eval "bashio::api.supervisor GET /network/interface/default/info false &> /dev/null ${LOG_FD}> /dev/null"; do
-  if (( wait_counter++ == WAIT_COUNT )); then
-    # We emit only a warning to let the app start, maybe this is the only connection to access the device, better to start than not.
-    # Let Tailscale figure out a way to connect to the tailnet if the local network is temporarily down.
-    # The app will emit warnings where it requires local network information, but can't get it.
-    bashio::log.warning "Local network (default Home Assistant interface) is unreachable"
-    break
-  fi
-  bashio::log.info "Waiting for the local network (default Home Assistant interface) to be ready..."
-  sleep $WAIT_DELAY
-done
-if (( wait_counter != 0 && wait_counter <= WAIT_COUNT )); then
-  bashio::log.info "Local network is ready"
-fi
+wait-for-local-network || true

--- a/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
+++ b/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
@@ -90,27 +90,38 @@ if bashio::var.has_value "${share_service_name}"; then
     bashio::app.option 'share_service_name'
 fi
 
-# Migrate advertise_routes option, replace "subnet_routes" with the actual values
+# Migrate advertise_routes option, replace "local_subnets" with the actual values
 advertise_routes=$(bashio::jq "${options}" '.advertise_routes | select(.!=null)')
 if bashio::var.has_value "${advertise_routes}" && \
     bashio::jq.has_value "${advertise_routes}" '.[] | select(.|test("^local_subnets$"))'
 then
-    bashio::log.info "Migrating advertise_routes option, replacing \"subnet_routes\" with the actual values"
-    # Read local subnets
-    readarray -t routes < <(subnet-routes local)
-    if (( 0 == ${#routes[@]} )); then
-        bashio::log.warning "There are no local subnets to add in place of \"subnet_routes\"!"
+    bashio::log.info "Migrating advertise_routes option, replacing \"local_subnets\" with the actual values"
+    if ! wait-for-local-network; then
+        bashio::log.warning \
+            "The local network is temporarily down, can't get local subnet information, can't migrate to actual values." \
+            "You have to add the local subnets to the advertise_routes option manually."
+        # Keep only user defined other subnets
+        readarray -t routes < <(bashio::jq "${advertise_routes}" '.[] | select(.|test("^local_subnets$")|not)')
+        # Save it
+        advertise_routes=$(bashio::var.json_array "${routes[@]}")
+        bashio::app.option 'advertise_routes' "^${advertise_routes}"
+    else
+        # Read local subnets
+        readarray -t routes < <(subnet-routes local)
+        if (( 0 == ${#routes[@]} )); then
+            bashio::log.warning "There are no local subnets to add in place of \"local_subnets\"!"
+        fi
+        # Add user defined other subnets
+        readarray -t -O "${#routes[@]}" routes < <(bashio::jq "${advertise_routes}" '.[] | select(.|test("^local_subnets$")|not)')
+        # Save it
+        advertise_routes=$(bashio::var.json_array "${routes[@]}")
+        bashio::app.option 'advertise_routes' "^${advertise_routes}"
+        # Reread to sanitize values, remove duplicates
+        readarray -t routes < <(subnet-routes advertised)
+        # Save it again
+        advertise_routes=$(bashio::var.json_array "${routes[@]}")
+        bashio::app.option 'advertise_routes' "^${advertise_routes}"
     fi
-    # Add user defined other subnets
-    readarray -t -O "${#routes[@]}" routes < <(bashio::jq "${advertise_routes}" '.[] | select(.|test("^local_subnets$")|not)')
-    # Save it
-    advertise_routes=$(bashio::var.json_array "${routes[@]}")
-    bashio::app.option 'advertise_routes' "^${advertise_routes}"
-    # Reread to sanitize values, remove duplicates
-    readarray -t routes < <(subnet-routes advertised)
-    # Save it again
-    advertise_routes=$(bashio::var.json_array "${routes[@]}")
-    bashio::app.option 'advertise_routes' "^${advertise_routes}"
 fi
 
 # Check DNS configuration

--- a/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
+++ b/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
@@ -7,6 +7,8 @@
 
 declare options
 declare proxy funnel proxy_and_funnel_port
+declare advertise_routes
+declare -a routes=()
 declare tags
 declare taildrive_addons taildrive_config
 declare share_service_name
@@ -86,6 +88,29 @@ share_service_name=$(bashio::jq "${options}" '.share_service_name | select(.!=nu
 if bashio::var.has_value "${share_service_name}"; then
     bashio::log.info 'Removing deprecated share_service_name option'
     bashio::app.option 'share_service_name'
+fi
+
+# Migrate advertise_routes option, replace "subnet_routes" with the actual values
+advertise_routes=$(bashio::jq "${options}" '.advertise_routes | select(.!=null)')
+if bashio::var.has_value "${advertise_routes}" && \
+    bashio::jq.has_value "${advertise_routes}" '.[] | select(.|test("^local_subnets$"))'
+then
+    bashio::log.info "Migrating advertise_routes option, replacing \"subnet_routes\" with the actual values"
+    # Read local subnets
+    readarray -t routes < <(subnet-routes local)
+    if (( 0 == ${#routes[@]} )); then
+        bashio::log.warning "There are no local subnets to add in place of \"subnet_routes\"!"
+    fi
+    # Add user defined other subnets
+    readarray -t -O "${#routes[@]}" routes < <(bashio::jq "${advertise_routes}" '.[] | select(.|test("^local_subnets$")|not)')
+    # Save it
+    advertise_routes=$(bashio::var.json_array "${routes[@]}")
+    bashio::app.option 'advertise_routes' "^${advertise_routes}"
+    # Reread to sanitize values, remove duplicates
+    readarray -t routes < <(subnet-routes advertised)
+    # Save it again
+    advertise_routes=$(bashio::var.json_array "${routes[@]}")
+    bashio::app.option 'advertise_routes' "^${advertise_routes}"
 fi
 
 # Check DNS configuration

--- a/tailscale/rootfs/usr/bin/subnet-routes
+++ b/tailscale/rootfs/usr/bin/subnet-routes
@@ -26,19 +26,7 @@ if bashio::cache.exists "subnet-routes-$1"; then
 else
   if [[ "$1" == "advertised" ]]; then
     # Use configured values
-    for address in $(bashio::config "advertise_routes"); do
-      if [[ "${address}" =~ ^local_subnets$ ]]; then
-        # Handle special value, collect local subnets
-        readarray -t routes < <(subnet-routes local)
-        if (( 0 == ${#routes[@]} )); then
-          bashio::log.warning \
-            "There are no local subnets to advertise!" \
-            "Restart of the app is required after the issue is fixed!"
-        fi
-      else
-        addresses+=("${address}")
-      fi
-    done
+    readarray -t addresses < <(bashio::config "advertise_routes")
   else
     # Find interfaces and matching addresses from which we can extract routes
     for interface in $(bashio::network.interfaces); do

--- a/tailscale/rootfs/usr/bin/wait-for-local-network
+++ b/tailscale/rootfs/usr/bin/wait-for-local-network
@@ -19,7 +19,7 @@ while ! eval "bashio::api.supervisor GET /network/interface/default/info false &
     # Let Tailscale figure out a way to connect to the tailnet if the local network is temporarily down.
     # The app will emit warnings where it requires local network information, but can't get it.
     bashio::log.warning "Local network (default Home Assistant interface) is unreachable"
-    exit 1
+    bashio::exit.nok
   fi
   bashio::log.info "Waiting for the local network (default Home Assistant interface) to be ready..."
   sleep $WAIT_DELAY

--- a/tailscale/rootfs/usr/bin/wait-for-local-network
+++ b/tailscale/rootfs/usr/bin/wait-for-local-network
@@ -1,0 +1,29 @@
+#!/usr/bin/env bashio
+# shellcheck shell=bash
+# ==============================================================================
+# Wait for the local network (default HA interface) to be ready
+# ==============================================================================
+
+readonly WAIT_DELAY=5   # 5s
+readonly WAIT_COUNT=60  # 60*5s = 300s = 5m
+
+declare wait_counter=0
+
+# Some services need a working local network to function properly.
+# They can mark this service as dependency, and wait for the successful startup.
+
+# Until HA has no default interface, we wait a little
+while ! eval "bashio::api.supervisor GET /network/interface/default/info false &> /dev/null ${LOG_FD}> /dev/null"; do
+  if (( wait_counter++ == WAIT_COUNT )); then
+    # We emit only a warning to let the app start, maybe this is the only connection to access the device, better to start than not.
+    # Let Tailscale figure out a way to connect to the tailnet if the local network is temporarily down.
+    # The app will emit warnings where it requires local network information, but can't get it.
+    bashio::log.warning "Local network (default Home Assistant interface) is unreachable"
+    exit 1
+  fi
+  bashio::log.info "Waiting for the local network (default Home Assistant interface) to be ready..."
+  sleep $WAIT_DELAY
+done
+if (( wait_counter != 0 && wait_counter <= WAIT_COUNT )); then
+  bashio::log.info "Local network is ready"
+fi

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -32,8 +32,6 @@ configuration:
     description: >-
       This option allows you to advertise routes to subnets (accessible on the network
       your device is connected to) to other clients on your tailnet.
-      By adding `local_subnets` to the list, the app will advertise routes to your
-      subnets on all supported interfaces.
   advertise_tags:
     name: Advertise tags
     description: >-


### PR DESCRIPTION
# Proposed Changes

This was needed when this config option was optional and we made it mandatory, this was the only way to preserve the previous behaviour during update/migration (when the optional option was missing, and SU added this as the default after it became mandatory to distinguish it from an already configured empty list).

Currently this is the only place where we have this magic value, users enter real IPs everywhere. It's time to replace it with the current values already used by the app. To be honest, we should have done this when we made it mandatory. SU would have added this as default and we would have replaced it on startup.

Note: This value must remain in the config schema to let the app start and migrate it. Though eg. a year from now it can be removed together with the migration logic.

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Existing `local_subnets` route configurations are migrated to concrete local subnet routes when the local network is available, while preserving custom routes.
  - Advertised routes are normalized to remove duplicates and ensure consistent route handling.
  - The addon now waits for the local network during migration and warns when subnets must be added manually if the network is unavailable.

- **Documentation**
  - Updated `advertise_routes` examples to use explicit IPv4 and IPv6 CIDR ranges.
  - Removed documentation for the `local_subnets` placeholder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->